### PR TITLE
LPS-73696 Add class to asset title

### DIFF
--- a/modules/apps/web-experience/asset/asset-publisher-web/src/main/resources/META-INF/resources/display/full_content.jsp
+++ b/modules/apps/web-experience/asset/asset-publisher-web/src/main/resources/META-INF/resources/display/full_content.jsp
@@ -67,7 +67,7 @@ request.setAttribute("view.jsp-showIconLabel", true);
 			/>
 		</c:if>
 
-		<span><%= HtmlUtil.escape(title) %></span>
+		<span class="header-title"><%= HtmlUtil.escape(title) %></span>
 	</c:if>
 
 	<c:if test="<%= !print %>">


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-73696

Forwarding from https://github.com/dustinryerson/liferay-portal/pull/154

From @zsagia:
> Please review Leendert's fix. You need to know that LPS-65442 refactored the related content in Asset Publisher and forgot to put a title class name to the span element. Originally it was header-title.
> 
> Our customer cannot catch this title easily.