### PR TITLE
[TECH SUPPORT] LPS-74437 ORMException is thrown after updating a site template when the portal is under load

### DIFF
--- a/portal-impl/src/com/liferay/portlet/sites/util/SitesImpl.java
+++ b/portal-impl/src/com/liferay/portlet/sites/util/SitesImpl.java
@@ -1363,7 +1363,7 @@ public class SitesImpl implements Sites {
 			sb.append(" and layout set ");
 			sb.append(layoutSet.getLayoutSetId());
 
-			_log.error(sb.toString(), e);
+			_log.warn(sb.toString(), e);
 
 			layoutSetPrototypeSettingsProperties.setProperty(
 				MERGE_FAIL_COUNT, String.valueOf(mergeFailCount));


### PR DESCRIPTION
Hi,
Could you please review this PR. The change is very simple it is needed because the log message is confusing.
https://issues.liferay.com/browse/LPS-74437
See for more explanation 
https://issues.liferay.com/browse/LPP-26797

Thanks,