### PR TITLE
LPS-74741 Unchecked null case in DDMTemplate

### DIFF
--- a/modules/apps/web-experience/portlet-display-template/portlet-display-template/src/main/java/com/liferay/portlet/display/template/internal/PortletDisplayTemplateImpl.java
+++ b/modules/apps/web-experience/portlet-display-template/portlet-display-template/src/main/java/com/liferay/portlet/display/template/internal/PortletDisplayTemplateImpl.java
@@ -416,12 +416,15 @@ public class PortletDisplayTemplateImpl implements PortletDisplayTemplate {
 		PortletResponse portletResponse = (PortletResponse)request.getAttribute(
 			JavaConstants.JAVAX_PORTLET_RESPONSE);
 
-		PortletURL currentURL = PortletURLUtil.getCurrent(
-			_portal.getLiferayPortletRequest(portletRequest),
-			_portal.getLiferayPortletResponse(portletResponse));
+		if ((portletRequest != null) && (portletResponse != null)) {
+			PortletURL currentURL = PortletURLUtil.getCurrent(
+				_portal.getLiferayPortletRequest(portletRequest),
+				_portal.getLiferayPortletResponse(portletResponse));
 
-		contextObjects.put(
-			PortletDisplayTemplateConstants.CURRENT_URL, currentURL.toString());
+			contextObjects.put(
+				PortletDisplayTemplateConstants.CURRENT_URL,
+				currentURL.toString());
+		}
 
 		contextObjects.put(PortletDisplayTemplateConstants.ENTRIES, entries);
 


### PR DESCRIPTION
Hey @dacousalr 

I'm István Dézsi, and I'm member to the Technical Support team in Budapest.

In https://github.com/natocesarrego/liferay-portal/pull/95#issuecomment-330533530 @natocesarrego suggested to send the pull request to you as being the SME in charge of Web Experience Management.

The solution deals with a case when `portletRequest` and `portletResponse` is `null` in `PortletDisplayTemplateImpl.renderDDMTemplate()`
This happens then the Language selector portlet is rendered.

A null value check clause used to be in `PortletDisplayTemplateImpl.renderDDMTemplate()` but it has been removed by https://issues.liferay.com/browse/LPS-73518, due to code simplification,
76f8de93d69c64973a18d91f3039feda33ac97db

This can lead to a NullPointerException.

I have not found valid reason why not to keep the null value check, so you re-added them, which solved the current issue.

Could you please check this solution?
Thank you very much!

Best regards,
István