### PR TITLE
LPS-74990 Adding a WebProxy portlet to a site template cause site templates propagation errors

### DIFF
--- a/modules/apps/foundation/web-proxy/web-proxy-web/src/main/resources/META-INF/portlet-preferences/default-portlet-preferences.xml
+++ b/modules/apps/foundation/web-proxy/web-proxy-web/src/main/resources/META-INF/portlet-preferences/default-portlet-preferences.xml
@@ -12,7 +12,6 @@
 	<preference>
 		<name>secureEdit</name>
 		<value>false</value>
-		<read-only>true</read-only>
 	</preference>
 	<preferences-validator>org.portletbridge.portlet.PortletBridgePortletValidator</preferences-validator>
 </portlet-preferences>


### PR DESCRIPTION
Hi,

Removed read-only as asked.

Regards, 
László