### PR TITLE
LPS-79748

### DIFF
--- a/modules/apps/web-experience/site/site-browser-web/src/main/java/com/liferay/site/browser/web/internal/display/context/SiteBrowserDisplayContext.java
+++ b/modules/apps/web-experience/site/site-browser-web/src/main/java/com/liferay/site/browser/web/internal/display/context/SiteBrowserDisplayContext.java
@@ -38,9 +38,11 @@ import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.PortalPreferences;
 import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
+import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
@@ -211,9 +213,8 @@ public class SiteBrowserDisplayContext {
 		else {
 			groups = GroupLocalServiceUtil.search(
 				company.getCompanyId(), classNameIds,
-				groupSearchTerms.getKeywords(), _getGroupParams(),
-				QueryUtil.ALL_POS, QueryUtil.ALL_POS,
-				groupSearch.getOrderByComparator());
+				groupSearchTerms.getKeywords(), null, QueryUtil.ALL_POS,
+				QueryUtil.ALL_POS, groupSearch.getOrderByComparator());
 
 			groups = _filterGroups(groups, themeDisplay.getPermissionChecker());
 
@@ -388,12 +389,18 @@ public class SiteBrowserDisplayContext {
 	}
 
 	private List<Group> _filterGroups(
-		List<Group> groups, PermissionChecker permissionChecker) {
+		List<Group> groups,
+		PermissionChecker permissionChecker) throws PortalException {
 
 		List<Group> filteredGroups = new ArrayList<>();
 
 		for (Group group : groups) {
-			if (permissionChecker.isGroupAdmin(group.getGroupId())) {
+			if (GroupPermissionUtil.contains(
+				permissionChecker, group.getGroupId(),
+				ActionKeys.VIEW) && GroupPermissionUtil.contains(
+					permissionChecker, group.getGroupId(),
+					ActionKeys.ASSIGN_MEMBERS)) {
+
 				filteredGroups.add(group);
 			}
 		}

--- a/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
@@ -4036,7 +4036,11 @@ public class GroupLocalServiceImpl extends GroupLocalServiceBaseImpl {
 			parentGroupIdEquals = false;
 		}
 
-		params = new LinkedHashMap<>(params);
+		if (params == null) {
+			params = new LinkedHashMap<>(0);
+		} else {
+			params = new LinkedHashMap<>(params);
+		}
 
 		Boolean active = (Boolean)params.remove("active");
 		List<Long> excludedGroupIds = (List<Long>)params.remove(


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-79748
Updated from https://github.com/ealonso/liferay-portal/pull/1615 -- changed the fix.

The issue I want to fix is where User X can't add Site A to User Y through user membership page (because filtering by roles) but User X has the permission to navigate to Site A and add User Y to membership anyways.

Let me know if there's a better way.  Membership Page assigning User Groups works as expected but assigning Sites does not.