### PR TITLE
[TECHNICAL-SUPPORT] LPS-81718

### DIFF
--- a/modules/apps/asset/asset-tags-service/src/main/java/com/liferay/asset/tags/internal/exportimport/data/handler/AssetTagStagedModelDataHandler.java
+++ b/modules/apps/asset/asset-tags-service/src/main/java/com/liferay/asset/tags/internal/exportimport/data/handler/AssetTagStagedModelDataHandler.java
@@ -20,14 +20,17 @@ import com.liferay.asset.kernel.service.AssetTagLocalService;
 import com.liferay.exportimport.data.handler.base.BaseStagedModelDataHandler;
 import com.liferay.exportimport.kernel.lar.ExportImportPathUtil;
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
+import com.liferay.exportimport.kernel.lar.PortletDataHandlerControl;
 import com.liferay.exportimport.kernel.lar.StagedModelDataHandler;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.xml.Element;
+import com.liferay.portal.util.PropsValues;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import org.osgi.service.component.annotations.Component;
@@ -133,9 +136,18 @@ public class AssetTagStagedModelDataHandler
 		AssetTag existingAssetTag = fetchStagedModelByUuidAndGroupId(
 			assetTag.getUuid(), portletDataContext.getScopeGroupId());
 
+		Map<String, String[]> parameterMap =
+			portletDataContext.getParameterMap();
+
+		boolean hasMergeParameter = parameterMap.containsKey(
+			PortletDataHandlerControl.getNamespacedControlName(
+				AssetTagsPortletDataHandler.NAMESPACE, "merge-tags-by-name"));
+
 		if (portletDataContext.getBooleanParameter(
 				AssetTagsPortletDataHandler.NAMESPACE, "merge-tags-by-name",
-				false)) {
+				false) ||
+			(!hasMergeParameter &&
+			 PropsValues.STAGING_PORTLET_MERGE_TAG_NAMES)) {
 
 			existingAssetTag = Optional.ofNullable(
 				_assetTagLocalService.fetchTag(

--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -1659,6 +1659,8 @@ public class PropsValues {
 
 	public static boolean STAGING_LIVE_GROUP_REMOTE_STAGING_ENABLED = GetterUtil.getBoolean(PropsUtil.get(PropsKeys.STAGING_LIVE_GROUP_REMOTE_STAGING_ENABLED));
 
+	public static boolean STAGING_PORTLET_MERGE_TAG_NAMES = GetterUtil.getBoolean(PropsUtil.get(PropsKeys.STAGING_PORTLET_MERGE_TAG_NAMES));
+
 	public static final int STAGING_REMOTE_TRANSFER_BUFFER_SIZE = GetterUtil.getInteger(PropsUtil.get(PropsKeys.STAGING_REMOTE_TRANSFER_BUFFER_SIZE));
 
 	public static final int STAGING_SYSTEM_EVENT_CHECK_INTERVAL = GetterUtil.getInteger(PropsUtil.get(PropsKeys.STAGING_SYSTEM_EVENT_CHECK_INTERVAL));

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -7026,6 +7026,13 @@
     staging.live.group.remote.staging.enabled=false
 
     #
+    # When accessing Staging using a specific portlet, such as Web Content, tags
+    # referenced by the Assets being published by that portlet will be merged by
+    # name.
+    #
+    staging.portlet.merge.tag.names=false
+
+    #
     # Set the file block sizes for remote staging. If a LAR file used for remote
     # staging exceeds this size, the file will be split into multiple files
     # prior to transmission and then reassembled on the remote server. The

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -2338,6 +2338,8 @@ public interface PropsKeys {
 
 	public static final String STAGING_LIVE_GROUP_REMOTE_STAGING_ENABLED = "staging.live.group.remote.staging.enabled";
 
+	public static final String STAGING_PORTLET_MERGE_TAG_NAMES = "staging.portlet.merge.tag.names";
+
 	public static final String STAGING_REMOTE_TRANSFER_BUFFER_SIZE = "staging.remote.transfer.buffer.size";
 
 	public static final String STAGING_SYSTEM_EVENT_CHECK_INTERVAL = "staging.system.event.check.interval";


### PR DESCRIPTION
/cc @joshuacords

Hello Daniel, @ealonso asked me to send this to you.

Notes from Josh:
> https://issues.liferay.com/browse/LPS-81718
> https://issues.liferay.com/browse/LPP-30238
> 
> Problem: Portals that have been updated from 6.2 can have Duplicate Asset Tags where the name is the same but their UUIDs are different. When an Asset referencing the tag attempts to be published, a DuplicateTagException is thrown. LPS-71451 as resolved this issue for portals that are upgraded from 6.2 directly to DE-35+ by allowing the "Merge by Tag Name" option, but portals that have published tags in DXP prior to DE-35 will be stuck with duplicate tags in the database.  While the "Merge by Tag Name" option works for the Advance Staging view, the Staging menu accessed through individual portlets, such as Web Content, do not offer the option to select "Merge by Tag Name", and will always fail to publish with the DuplicateTagException.
> 
> Solution: Add a portal property "staging.portlet.merge.tag.names" that allow portal administrators to change the default "Merge by Tag Names" to true to work around the duplicate tags in the database. This property only affects Staging from different asset portlets and does not change the behavior of the Advance Staging page.