### PR TITLE
LPS-88437 friendlyURL can be empty for ddmStructure default values

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -5664,7 +5664,15 @@ public class JournalArticleLocalServiceImpl
 
 		String urlTitle = urlTitleMap.get(LocaleUtil.toLanguageId(locale));
 
-		if (Validator.isNull(urlTitle)) {
+		boolean articleIsDDMStructure = false;
+
+		if (classNameLocalService.getClassNameId(DDMStructure.class) ==
+				article.getClassNameId()) {
+
+			articleIsDDMStructure = true;
+		}
+
+		if (Validator.isNull(urlTitle) && !articleIsDDMStructure) {
 			throw new ArticleFriendlyURLException();
 		}
 
@@ -5741,9 +5749,7 @@ public class JournalArticleLocalServiceImpl
 
 		// Dynamic data mapping
 
-		if (classNameLocalService.getClassNameId(DDMStructure.class) ==
-				article.getClassNameId()) {
-
+		if (articleIsDDMStructure) {
 			updateDDMStructurePredefinedValues(
 				article.getClassPK(), content, serviceContext);
 		}


### PR DESCRIPTION
Hi @dacousalr 

https://issues.liferay.com/browse/LPS-88437

According to my investigation, the journal article records belonging to a ddm structure have null as urlTitle, so I think it is ok to narrow down the validation to exclude ddm structures.
What do you think?

Thanks,
