### PR TITLE
LPS-88434 Use the original categoryIds if there's no permissionChecker available

### DIFF
--- a/portal-impl/src/com/liferay/portlet/asset/util/AssetUtil.java
+++ b/portal-impl/src/com/liferay/portlet/asset/util/AssetUtil.java
@@ -215,6 +215,10 @@ public class AssetUtil {
 			PermissionChecker permissionChecker, long[] categoryIds)
 		throws PortalException {
 
+		if (permissionChecker == null) {
+			return categoryIds;
+		}
+
 		List<Long> viewableCategoryIds = new ArrayList<>();
 
 		for (long categoryId : categoryIds) {


### PR DESCRIPTION
Hi Daniel,

Please find my solution suggestion for LPS-88434. Could you please review my changes?
Furthermore, I feel like some explanation is in order as to why I chose this solution.
1. I realize that I changed a method of deprecated class, but it looks like that's the one called from the AssetSearcher.addSearchAnyCategories upon querying the assets for the notification email. I found that the AssetUtil class was moved to the web-experience/asset/asset-service module by LPS-74303, but on master, where the web-experience is not available any more, there's no AssetUtil class in the asset modules and the AssetHelper doesn't contain the necessary method.

2. I included a simple null check because I found other places in the portal as well where this was used:
https://github.com/liferay/liferay-portal/blob/1434fc59f69778ab2ed3aae0bf61e6c6e58aaae7/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetEntryLocalServiceImpl.java#L1165
https://github.com/liferay/liferay-portal/blob/1434fc59f69778ab2ed3aae0bf61e6c6e58aaae7/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetCategoryLocalServiceImpl.java#L458

During my tests I experienced that the Asset Publisher doesn't take into account the permissions of the categories. If the user has permissions for the Web Content they can see the content in the Asset Publisher and receive notification of it, even if they don't have view permission of the belonging category. This appears to be a different issue from the current one, but could affect the test results of this.

I think these suggest that this simple null check should be the solution, but I'm not quite sure if this is indeed the best approach.
What do you think?

Thank you,
Laci