### PR TITLE
[TECHNICAL-SUPPORT] LPS-88316

### DIFF
--- a/modules/apps/asset/asset-publisher-test/src/testIntegration/java/com/liferay/asset/publisher/portlet/test/DisplayPageFriendlyURLResolverTest.java
+++ b/modules/apps/asset/asset-publisher-test/src/testIntegration/java/com/liferay/asset/publisher/portlet/test/DisplayPageFriendlyURLResolverTest.java
@@ -212,7 +212,7 @@ public class DisplayPageFriendlyURLResolverTest {
 			StringBundler.concat(
 				"No JournalArticle exists with the key {groupId=",
 				_group.getGroupId(), ", urlTitle=", urlTitle, ", status=",
-				WorkflowConstants.STATUS_APPROVED, "}"),
+				WorkflowConstants.STATUS_PENDING, "}"),
 			cause.getMessage());
 	}
 


### PR DESCRIPTION
Resent from https://github.com/dacousalr/liferay-portal/pull/84

> Relevant tickets:
> 
> https://issues.liferay.com/browse/LPP-32287
> https://issues.liferay.com/browse/LPS-88316
> 
> Using the "View in Context" link under My Workflow Tasks for a pending article (with a configured display page) does not work if there are no approved versions of that article.
> 
> This is due to changes to both the getActualURL() and getJournalArticleLayout() methods in two previous changes:
> 
> liferay@ffc21d1#diff-88404608066b298ac8f681687363f86b
> liferay@f418247#diff-88404608066b298ac8f681687363f86b
> 
> With these changes, only approved versions can be viewed in context this way. However, we believe this is not correct, as it renders the "View in Context" link for workflow tasks non-functional unless there are already previously approved versions.

It seems to work with this implementation from the component, checking after retrieving the pending article if it exists. We tested with different roles, and it appears to conform to what we expect, if we configure the Workflow to assign the workflow task to the role as it would to an admin or content reviewer.

Please let us know what you think about this, or if there are any other concerns. Thank you.