### PR TITLE
LPS-88951 Adding p_l_id to URLs so that themeDisplays can be initialized correctly

### DIFF
--- a/portal-impl/src/com/liferay/portlet/layoutsadmin/util/SitemapImpl.java
+++ b/portal-impl/src/com/liferay/portlet/layoutsadmin/util/SitemapImpl.java
@@ -281,7 +281,7 @@ public class SitemapImpl implements Sitemap {
 
 				Element locationElement = sitemapElement.addElement("loc");
 
-				StringBundler sb = new StringBundler(8);
+				StringBundler sb = new StringBundler(10);
 
 				sb.append(portalURL);
 				sb.append(PortalUtil.getPathContext());
@@ -291,6 +291,8 @@ public class SitemapImpl implements Sitemap {
 				sb.append(layoutSet.getGroupId());
 				sb.append("&privateLayout=");
 				sb.append(layout.isPrivateLayout());
+				sb.append("&p_l_id=");
+				sb.append(layout.getPlid());
 
 				locationElement.addText(sb.toString());
 			}


### PR DESCRIPTION
Hi @dacousalr ,

The issue's root cause was that themeDisplay was not correctly initialized in the ServicePreAction.
The original intent might have been to use the layoutUUID from the URL parameters to identify the correct layout and it's group, but PortalImpl#getAlternateURLs uses the themeDisplay instead of the layout to determine available languages.
I felt safer to modify only the SiteMapImpl, as I couldn't imagine what other consequences modifying the PortalImpl might have produced.

This might highlight that the layoutUUID parameter is unnecessary in the sitemap URLs.

What do you think?

Thanks