### PR TITLE
LPS-89352 Create view history configuration icon for edit_article view

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/configuration/icon/ViewHistoryPortletConfigurationIcon.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/configuration/icon/ViewHistoryPortletConfigurationIcon.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.journal.web.internal.portlet.configuration.icon;
+
+import com.liferay.journal.constants.JournalPortletKeys;
+import com.liferay.journal.model.JournalArticle;
+import com.liferay.journal.web.internal.portlet.action.ActionUtil;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.portlet.configuration.icon.BaseJSPPortletConfigurationIcon;
+import com.liferay.portal.kernel.portlet.configuration.icon.PortletConfigurationIcon;
+
+import javax.portlet.PortletRequest;
+import javax.portlet.PortletResponse;
+
+import javax.servlet.ServletContext;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Balázs Sáfrány-Kovalik
+ */
+@Component(
+	immediate = true,
+	property = {
+		"javax.portlet.name=" + JournalPortletKeys.JOURNAL,
+		"path=/edit_article.jsp"
+	},
+	service = PortletConfigurationIcon.class
+)
+public class ViewHistoryPortletConfigurationIcon
+	extends BaseJSPPortletConfigurationIcon {
+
+	@Override
+	public String getJspPath() {
+		return "/configuration/icon//view_history.jsp";
+	}
+
+	@Override
+	public String getMessage(PortletRequest portletRequest) {
+		return LanguageUtil.get(
+			getResourceBundle(getLocale(portletRequest)), "view-history");
+	}
+
+	@Override
+	public String getURL(
+		PortletRequest portletRequest, PortletResponse portletResponse) {
+
+		return "javascript:;";
+	}
+
+	@Override
+	public double getWeight() {
+		return 500.0;
+	}
+
+	@Override
+	public boolean isShow(PortletRequest portletRequest) {
+		try {
+			JournalArticle article = ActionUtil.getArticle(portletRequest);
+
+			if ((article != null) && !article.isNew()) {
+				return true;
+			}
+		}
+		catch (Exception e) {
+		}
+
+		return false;
+	}
+
+	@Override
+	public boolean isToolTip() {
+		return false;
+	}
+
+	@Override
+	@Reference(
+		target = "(osgi.web.symbolicname=com.liferay.journal.web)", unbind = "-"
+	)
+	public void setServletContext(ServletContext servletContext) {
+		super.setServletContext(servletContext);
+	}
+
+}

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/configuration/icon/view_history.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/configuration/icon/view_history.jsp
@@ -1,0 +1,35 @@
+<%--
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+--%>
+
+<%@ include file="/init.jsp" %>
+
+<%
+JournalArticle article = ActionUtil.getArticle(renderRequest);
+%>
+
+<liferay-portlet:renderURL var="viewArticleHistoryURL">
+	<portlet:param name="mvcPath" value="/view_article_history.jsp" />
+	<portlet:param name="groupId" value="<%= String.valueOf(article.getGroupId()) %>" />
+	<portlet:param name="articleId" value="<%= article.getArticleId() %>" />
+	<portlet:param name="redirect" value="<%= currentURL %>" />
+	<portlet:param name="backURL" value="<%= currentURL %>" />
+</liferay-portlet:renderURL>
+
+<liferay-ui:icon
+	id="basicViewHistoryButton"
+	message="view-history"
+	url="<%= viewArticleHistoryURL %>"
+/>


### PR DESCRIPTION
Hi @dacousalr ,

https://issues.liferay.com/browse/LPS-89352

I've followed your suggestion from https://issues.liferay.com/browse/LPS-89352?focusedCommentId=1684105#comment-1684105 and added the new PCI to the edit_article view.

I have some questions, maybe you can help me out on them:
1. You mentioned that there is a possibility to customize this to appear on JournalContentPortlets as well, however I could not get that working with simply adding another javax.portlet.name. PortletConfigurationIconServiceReferenceMapper#map seems to limit it to one value. Should this be updated to use multiple ones?
2. I couldn't get this PCI to display on a JCP, I tried to use 
"javax.portlet.name=com_liferay_journal_content_web_portlet_JournalContentPortlet" with "path=/view.jsp", maybe I've got the how path works wrong, can you please explain it to me?



Thanks,
