### PR TITLE
LPS-89507

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutPageTemplateManagementToolbarDisplayContext.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutPageTemplateManagementToolbarDisplayContext.java
@@ -21,6 +21,7 @@ import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemList;
 import com.liferay.layout.page.template.constants.LayoutPageTemplateActionKeys;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
@@ -103,16 +104,22 @@ public class LayoutPageTemplateManagementToolbarDisplayContext
 							LanguageUtil.get(request, "content-page-template"));
 					});
 
-				addPrimaryDropdownItem(
-					dropdownItem -> {
-						dropdownItem.putData(
-							"action", "addLayoutPageTemplateEntry");
-						dropdownItem.putData(
-							"addPageTemplateURL", _getAddLayoutPrototypeURL());
-						dropdownItem.setHref("#");
-						dropdownItem.setLabel(
-							LanguageUtil.get(request, "widget-page-template"));
-					});
+				Group scopeGroup = _themeDisplay.getScopeGroup();
+
+				if (scopeGroup.isSite()) {
+					addPrimaryDropdownItem(
+						dropdownItem -> {
+							dropdownItem.putData(
+								"action", "addLayoutPageTemplateEntry");
+							dropdownItem.putData(
+								"addPageTemplateURL",
+								_getAddLayoutPrototypeURL());
+							dropdownItem.setHref("#");
+							dropdownItem.setLabel(
+								LanguageUtil.get(
+									request, "widget-page-template"));
+						});
+				}
 			}
 		};
 	}

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/LayoutPageTemplateServiceUpgrade.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/LayoutPageTemplateServiceUpgrade.java
@@ -16,6 +16,7 @@ package com.liferay.layout.page.template.internal.upgrade;
 
 import com.liferay.fragment.service.FragmentEntryLinkLocalService;
 import com.liferay.layout.page.template.internal.upgrade.v1_1_0.UpgradeLayoutPrototype;
+import com.liferay.layout.page.template.internal.upgrade.v1_1_1.UpgradeLayoutPageTemplateEntry;
 import com.liferay.layout.page.template.internal.upgrade.v1_2_0.UpgradeLayoutPageTemplateStructure;
 import com.liferay.layout.page.template.internal.upgrade.v2_0_0.util.LayoutPageTemplateCollectionTable;
 import com.liferay.layout.page.template.internal.upgrade.v2_0_0.util.LayoutPageTemplateEntryTable;
@@ -47,7 +48,11 @@ public class LayoutPageTemplateServiceUpgrade
 				_companyLocalService, _layoutPrototypeLocalService));
 
 		registry.register(
-			"1.1.0", "1.2.0",
+			"1.1.0", "1.1.1",
+			new UpgradeLayoutPageTemplateEntry(_companyLocalService));
+
+		registry.register(
+			"1.1.1", "1.2.0",
 			new UpgradeLayoutPageTemplateStructure(
 				_fragmentEntryLinkLocalService, _layoutLocalService));
 

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v1_1_1/UpgradeLayoutPageTemplateEntry.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v1_1_1/UpgradeLayoutPageTemplateEntry.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.layout.page.template.internal.upgrade.v1_1_1;
+
+import com.liferay.layout.page.template.constants.LayoutPageTemplateEntryTypeConstants;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+/**
+ * @author Jonathan McCann
+ */
+public class UpgradeLayoutPageTemplateEntry extends UpgradeProcess {
+
+	public UpgradeLayoutPageTemplateEntry(
+		CompanyLocalService companyLocalService) {
+
+		_companyLocalService = companyLocalService;
+	}
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		StringBundler sb = new StringBundler(5);
+
+		sb.append("select layoutPageTemplateEntryId, companyId, name from ");
+		sb.append("LayoutPageTemplateEntry where type_ = ");
+		sb.append(LayoutPageTemplateEntryTypeConstants.TYPE_WIDGET_PAGE);
+		sb.append(" and groupId in (select groupId from Group_ where site = ");
+		sb.append("0)");
+
+		try (PreparedStatement ps = connection.prepareStatement(sb.toString());
+			ResultSet rs = ps.executeQuery()) {
+
+			while (rs.next()) {
+				long layoutPageTemplateEntryId = rs.getLong(
+					"layoutPageTemplateEntryId");
+				long companyId = rs.getLong("companyId");
+				String name = rs.getString("name");
+
+				_updateLayoutPageTemplateEntry(
+					layoutPageTemplateEntryId, companyId, name);
+			}
+		}
+	}
+
+	private void _updateLayoutPageTemplateEntry(
+			long layoutPageTemplateEntryId, long companyId, String name)
+		throws Exception {
+
+		Company company = _companyLocalService.getCompany(companyId);
+
+		for (int i = 1;; i++) {
+			StringBundler sb = new StringBundler(6);
+
+			sb.append("select count(*) from LayoutPageTemplateEntry where ");
+			sb.append("groupId = ");
+			sb.append(company.getGroupId());
+			sb.append(" and name = '");
+			sb.append(name);
+			sb.append("'");
+
+			try (PreparedStatement ps = connection.prepareStatement(
+					sb.toString());
+				ResultSet rs = ps.executeQuery()) {
+
+				if (rs.next() && (rs.getInt(1) > 0)) {
+					name = name + i;
+				}
+				else {
+					break;
+				}
+ 			}
+		}
+
+		StringBundler sb = new StringBundler(6);
+
+		sb.append("update LayoutPageTemplateEntry set groupId = ");
+		sb.append(company.getGroupId());
+		sb.append(", layoutPageTemplateCollectionId = 0, name = '");
+		sb.append(name);
+		sb.append("' where layoutPageTemplateEntryId = ");
+		sb.append(layoutPageTemplateEntryId);
+
+		runSQL(sb.toString());
+	}
+
+	private final CompanyLocalService _companyLocalService;
+
+}


### PR DESCRIPTION
Hello @dacousalr @jkappler,

This is my current implementation for the Site and Page Template issue and I wanted to get your feedback to make sure this is what you wanted. Additionally, I wanted to bring up some issues I'm facing with it currently.

1. When there is only a single dropdown menu item in the navigation menu, the button itself does not work (https://github.com/dacousalr/liferay-portal/commit/cee72321d31578b659c4e1a1c475db18865a1022). This can also be seen when going to **Page Fragments - Resources**.

2. I am unable to delete the previously created Widget Page Templates within a Site that is based off of a Site Template. There does not seem to be a differentiation between a LayoutPageTemplateEntry that is created from a Site Template and one created by importing from a LAR. I cannot safely remove the invalid entries without potentially losing other information. I'm not sure if this is something that is necessary to clean up but as it stands it will serve no purpose after this upgrade is run.

3. When exporting and importing a site that contains a Widget Page Template, both sites are tied to the same LayoutPrototype so any modifications on one site affects the other. This is not directly related to the issue at hand but something I noticed during my testing.

Please let me know your thoughts and what needs to be reworked with current implementation.

Thank you.