### PR TITLE
[TS] LPS-93308 GroupId is needed with articleId to identify the correct jo…

### DIFF
--- a/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/display/context/JournalContentDisplayContext.java
+++ b/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/display/context/JournalContentDisplayContext.java
@@ -669,6 +669,9 @@ public class JournalContentDisplayContext {
 
 			portletURL.setParameter("articleId", article.getArticleId());
 
+			portletURL.setParameter(
+				"groupId", String.valueOf(article.getGroupId()));
+
 			portletURL.setWindowState(LiferayWindowState.POP_UP);
 
 			portletURL.setParameter(


### PR DESCRIPTION
…urnalArticle

Hi @dacousalr ,
As I was backporting LPS-89352 I noticed that web contents from outside of site scope can't open a view history modal.
I've tracked down the issue to https://github.com/liferay/liferay-portal/blob/master/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/ActionUtil.java#L257 where groupId is set to scopeGroupId if none is explicitly set.

Can you please review?

Thanks,