### PR TITLE
LPS-93533 Don't allow 0 siteNavigationMenuId, as that is equal to the…

### DIFF
--- a/modules/apps/site-navigation/site-navigation-menu-item-layout/src/main/java/com/liferay/site/navigation/menu/item/layout/internal/model/listener/LayoutModelListener.java
+++ b/modules/apps/site-navigation/site-navigation-menu-item-layout/src/main/java/com/liferay/site/navigation/menu/item/layout/internal/model/listener/LayoutModelListener.java
@@ -70,7 +70,9 @@ public class LayoutModelListener extends BaseModelListener<Layout> {
 				CharPool.COMMA));
 
 		for (long siteNavigationMenuId : siteNavigationMenuIds) {
-			_addSiteNavigationMenuItem(siteNavigationMenuId, layout);
+			if (siteNavigationMenuId > 0) {
+				_addSiteNavigationMenuItem(siteNavigationMenuId, layout);
+			}
 		}
 	}
 


### PR DESCRIPTION
… siteNavigationMenuId=false layout typeSetting

Hi @dacousalr ,

We have received reports of SiteNavigationMenuItems breaking staging and found that when creating pages when the add to navigation menu checkbox is unchecked one SiteNavigationMenuItem is created.

https://issues.liferay.com/browse/LPS-93533

Can you please review?

In addition to this fix, I'd like to provide the following script to the reporters:
`
import com.liferay.site.navigation.service.SiteNavigationMenuItemLocalServiceUtil;

SiteNavigationMenuItemLocalServiceUtil.deleteSiteNavigationMenuItems(0);
`
What do you think?


Thanks,
