### PR TITLE
LPS-95644 Expired Web Contents have incorrect status in search index

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -7197,7 +7197,11 @@ public class JournalArticleLocalServiceImpl
 					_log.debug("Expiring article " + article.getId());
 				}
 
-				if (isExpireAllArticleVersions(article.getCompanyId())) {
+				long companyId = article.getCompanyId();
+
+				indexableActionableDynamicQuery.setCompanyId(companyId);
+
+				if (isExpireAllArticleVersions(companyId)) {
 					List<JournalArticle> currentArticles =
 						journalArticlePersistence.findByG_A(
 							article.getGroupId(), article.getArticleId(),

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -5454,6 +5454,9 @@ public class JournalArticleLocalServiceImpl
 					return;
 				}
 
+				indexableActionableDynamicQuery.setCompanyId(
+					article.getCompanyId());
+
 				com.liferay.portal.kernel.search.Document document =
 					indexer.getDocument(article);
 


### PR DESCRIPTION
[LPS-95644](https://issues.liferay.com/browse/LPS-95644)

Hi Daniel,

I hope you can review my changes.

The issue is that at scheduled Web Content expiration the updated index documents are put into the SYSTEM index.

ElasticsearchIndexWriter.updateDocuments() calls searchContext.getCompanyId() when composing the indexName. Previously, the value of searchContext._companyId is set based on what comes from the IndexableActionableDynamicQuery. That is all what is important about my changes.

Pleas let me know if there is anything I can help you with.

Thank you,
Istvan 