### PR TITLE
[TS] LPS-95585 Only Global group is accesible from page templates

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/staging/StagingImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/staging/StagingImpl.java
@@ -87,6 +87,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.messaging.DestinationNames;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutBranch;
@@ -112,6 +113,7 @@ import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutBranchLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
@@ -2116,6 +2118,25 @@ public class StagingImpl implements Staging {
 
 	@Override
 	public boolean isGroupAccessible(Group group, Group fromGroup) {
+		if (fromGroup == null) {
+			long companyId = group.getCompanyId();
+
+			try {
+				Company company = _companyLocalService.getCompany(companyId);
+
+				Group companyGroup = company.getGroup();
+
+				if (group.equals(companyGroup)) {
+					return true;
+				}
+			}
+			catch (PortalException e) {
+				_log.warn("Couldn't find Global group.");
+			}
+
+			return false;
+		}
+
 		if (group.equals(fromGroup)) {
 			return true;
 		}
@@ -4189,6 +4210,9 @@ public class StagingImpl implements Staging {
 
 	@Reference
 	private ClassNameLocalService _classNameLocalService;
+
+	@Reference
+	private CompanyLocalService _companyLocalService;
 
 	@Reference
 	private CTEngineManager _ctEngineManager;

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/staging/StagingImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/staging/StagingImpl.java
@@ -2130,8 +2130,10 @@ public class StagingImpl implements Staging {
 					return true;
 				}
 			}
-			catch (PortalException e) {
-				_log.warn("Couldn't find Global group.");
+			catch (PortalException pe) {
+				if (_log.isWarnEnabled()) {
+					_log.warn("Global group not found", pe);
+				}
 			}
 
 			return false;


### PR DESCRIPTION
Hi @dacousalr 
This is an alternative way for the Page Template problem.
Instead of removing the AssetSelector from the WCD Setup this adapts the logic of using nulls instead of page templates as parameter for isGroupAccessible.

This will let us select Global assets.
Of course, this will need a little tweak on the LPS description.

https://issues.liferay.com/browse/LPS-95585

Thanks,
