### PR TITLE
[TS] LPS-96035 SlidingWindowSearcher is not used for searchCount() method

### DIFF
--- a/modules/apps/asset/asset-browser-web/src/main/java/com/liferay/asset/browser/web/internal/display/context/AssetBrowserDisplayContext.java
+++ b/modules/apps/asset/asset-browser-web/src/main/java/com/liferay/asset/browser/web/internal/display/context/AssetBrowserDisplayContext.java
@@ -126,14 +126,6 @@ public class AssetBrowserDisplayContext {
 			sort = new Sort(sortFieldName, Sort.STRING_TYPE, orderByAsc);
 		}
 
-		int total = (int)AssetEntryLocalServiceUtil.searchCount(
-			themeDisplay.getCompanyId(), _getFilterGroupIds(),
-			themeDisplay.getUserId(), _getClassNameIds(),
-			getSubtypeSelectionId(), _getKeywords(), _isShowNonindexable(),
-			_getStatuses());
-
-		assetBrowserSearch.setTotal(total);
-
 		Hits hits = AssetEntryLocalServiceUtil.search(
 			themeDisplay.getCompanyId(), _getFilterGroupIds(),
 			themeDisplay.getUserId(), _getClassNameIds(),
@@ -144,6 +136,8 @@ public class AssetBrowserDisplayContext {
 		List<AssetEntry> assetEntries = _assetHelper.getAssetEntries(hits);
 
 		assetBrowserSearch.setResults(assetEntries);
+
+		assetBrowserSearch.setTotal(hits.getLength());
 
 		return assetBrowserSearch;
 	}


### PR DESCRIPTION
[LPS-96035](https://issues.liferay.com/browse/LPS-96035)

Hi Daniel,

Please review my changes.

[LPS-74395](https://issues.liferay.com/browse/LPS-74395) solved a search permission filter performance issue, but it still persist when searchCount() is called. The reason is that the introduced SlidingWindowSearcher doesn't get activated as it depends on the *start* and *end* values which we define for *search* method, but cannot supply for *searchCount*.

Please let me know if there is anything I can help you with.

Thank you,
Istvan