### PR TITLE
LPS-97838 Adding extension to filename so that DLFileEntry can get it

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v1_1_0/UpgradeImageTypeContent.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v1_1_0/UpgradeImageTypeContent.java
@@ -154,15 +154,6 @@ public class UpgradeImageTypeContent extends UpgradeProcess {
 
 		@Override
 		public Boolean call() throws Exception {
-			String fileName = String.valueOf(_articleImageId);
-
-			FileEntry fileEntry = _portletFileRepository.fetchPortletFileEntry(
-				_groupId, _folderId, fileName);
-
-			if (fileEntry != null) {
-				return null;
-			}
-
 			try {
 				Image image = _imageLocalService.getImage(_articleImageId);
 
@@ -170,8 +161,18 @@ public class UpgradeImageTypeContent extends UpgradeProcess {
 					return null;
 				}
 
-				String mimeType = MimeTypesUtil.getContentType(
-					fileName + StringPool.PERIOD + image.getType());
+				String fileName =
+					_articleImageId + StringPool.PERIOD + image.getType();
+
+				FileEntry fileEntry =
+					_portletFileRepository.fetchPortletFileEntry(
+						_groupId, _folderId, fileName);
+
+				if (fileEntry != null) {
+					return null;
+				}
+
+				String mimeType = MimeTypesUtil.getContentType(fileName);
 
 				_portletFileRepository.addPortletFileEntry(
 					_groupId, _userId, JournalArticle.class.getName(),
@@ -182,8 +183,8 @@ public class UpgradeImageTypeContent extends UpgradeProcess {
 			}
 			catch (Exception e) {
 				_log.error(
-					"Unable to add the journal article image " + fileName +
-						" into the file repository",
+					"Unable to add the journal article image " +
+						_articleImageId + " into the file repository",
 					e);
 
 				return false;


### PR DESCRIPTION
Hi @dacousalr ,

We have found that DLFileEntry-s take their extension property from their filename parameter. In the JournalArticleImage migration, currently only the articleImageId was given as filename, so the DLFileEntry-s were left extensionless after the upgrade.

Can you please review?
https://issues.liferay.com/browse/LPS-97838

Thanks,
