### PR TITLE
[TS] LPS-98112 Add fileEntryId to JSON

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v1_1_5/UpgradeContentImages.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v1_1_5/UpgradeContentImages.java
@@ -112,6 +112,8 @@ public class UpgradeContentImages extends UpgradeProcess {
 						GetterUtil.getString(
 							dynamicContentElement.attributeValue("alt"))
 					).put(
+						"fileEntryId", fileEntry.getFileEntryId()
+					).put(
 						"groupId", fileEntry.getGroupId()
 					).put(
 						"name", fileEntry.getFileName()


### PR DESCRIPTION
Hi @dacousalr ,
If I'm correct, the source of this inconsistency is https://issues.liferay.com/browse/LPS-70955, where fileEntryId was added to the Image's content JSON.

Can you please review?
https://issues.liferay.com/browse/LPS-98112

Thanks,
Balázs