### PR TITLE
LPS-106584 Setting siteDefaultLocale for localisable fields

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v0_0_5/UpgradeJournal.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v0_0_5/UpgradeJournal.java
@@ -39,6 +39,7 @@ import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.upgrade.util.UpgradeProcessUtil;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.LocaleThreadLocal;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.LoggingTimer;
 import com.liferay.portal.kernel.util.PortalUtil;
@@ -109,18 +110,27 @@ public class UpgradeJournal extends UpgradeProcess {
 
 		Class<?> clazz = getClass();
 
-		_defaultDDMStructureHelper.addDDMStructures(
-			defaultUserId, group.getGroupId(),
-			PortalUtil.getClassNameId(JournalArticle.class),
-			clazz.getClassLoader(),
-			"com/liferay/journal/internal/upgrade/v1_0_0/dependencies" +
-				"/basic-web-content-structure.xml",
-			new ServiceContext());
-
-		addDefaultResourcePermissions(group.getGroupId());
+		Locale oldLocale = LocaleThreadLocal.getSiteDefaultLocale();
 
 		Locale defaultLocale = LocaleUtil.fromLanguageId(
 			UpgradeProcessUtil.getDefaultLanguageId(companyId));
+
+		LocaleThreadLocal.setSiteDefaultLocale(defaultLocale);
+
+		try {
+			_defaultDDMStructureHelper.addDDMStructures(
+				defaultUserId, group.getGroupId(),
+				PortalUtil.getClassNameId(JournalArticle.class),
+				clazz.getClassLoader(),
+				"com/liferay/journal/internal/upgrade/v1_0_0/dependencies" +
+				"/basic-web-content-structure.xml",
+				new ServiceContext());
+		}
+		finally {
+			LocaleThreadLocal.setSiteDefaultLocale(oldLocale);
+		}
+
+		addDefaultResourcePermissions(group.getGroupId());
 
 		List<Element> structureElements = getDDMStructures(defaultLocale);
 


### PR DESCRIPTION
Hi @dacousalr ,

**Root cause**
This change https://github.com/liferay/liferay-portal/commit/6872682a09ffc3865e7258f4997a22478f80856a#diff-5f092cac92a739f56737ac7c5ed8b20dL1766 removed the group based checking for locales. The reasoning behind the change might have been a performance improvement, but there is a special case with upgrades. I couldn't find where LocaleThreadLocal is initially set during the upgrade process, so it either defaults to "en_US" or null for the site's default locale.

**Solution**
Ensure that LocaleThreadLocal is using the correct locale from the group during this upgrade step.


Can you please review?
https://issues.liferay.com/browse/LPS-106584

Thanks,
Balázs