### PR TITLE
LPS-106477

### DIFF
--- a/portal-impl/src/com/liferay/portal/action/UpdateLanguageAction.java
+++ b/portal-impl/src/com/liferay/portal/action/UpdateLanguageAction.java
@@ -94,21 +94,25 @@ public class UpdateLanguageAction implements Action {
 		String redirect = PortalUtil.escapeRedirect(
 			ParamUtil.getString(httpServletRequest, "redirect"));
 
-		String layoutURL = StringPool.BLANK;
+		String layoutURL = redirect;
+
+		String friendlyURLSeparatorPart = StringPool.BLANK;
 		String queryString = StringPool.BLANK;
 
-		int pos = redirect.indexOf(Portal.FRIENDLY_URL_SEPARATOR);
+		int posQuestion = redirect.indexOf(StringPool.QUESTION);
 
-		if (pos == -1) {
-			pos = redirect.indexOf(StringPool.QUESTION);
+		if (posQuestion != -1) {
+			queryString = redirect.substring(posQuestion);
+			layoutURL = redirect.substring(0, posQuestion);
 		}
 
-		if (pos != -1) {
-			layoutURL = redirect.substring(0, pos);
-			queryString = redirect.substring(pos);
-		}
-		else {
-			layoutURL = redirect;
+		int posFriendlyURLSeparator = layoutURL.indexOf(
+			Portal.FRIENDLY_URL_SEPARATOR);
+
+		if (posFriendlyURLSeparator != -1) {
+			friendlyURLSeparatorPart = layoutURL.substring(
+				posFriendlyURLSeparator);
+			layoutURL = layoutURL.substring(0, posFriendlyURLSeparator);
 		}
 
 		if (themeDisplay.isI18n()) {

--- a/portal-impl/src/com/liferay/portal/action/UpdateLanguageAction.java
+++ b/portal-impl/src/com/liferay/portal/action/UpdateLanguageAction.java
@@ -123,7 +123,7 @@ public class UpdateLanguageAction implements Action {
 
 		Layout layout = themeDisplay.getLayout();
 
-		if (isFriendlyURLResolver(layoutURL)) {
+		if (isFriendlyURLResolver(layoutURL) || layout.isTypeControlPanel()) {
 			redirect = layoutURL + friendlyURLSeparatorPart;
 		}
 		else if (layoutURL.equals(StringPool.SLASH) ||
@@ -147,11 +147,6 @@ public class UpdateLanguageAction implements Action {
 			if (Validator.isNotNull(friendlyURLSeparatorPart)) {
 				redirect += friendlyURLSeparatorPart;
 			}
-		}
-		else if (layout.isTypeControlPanel() && themeDisplay.isI18n()) {
-			String i18nPath = themeDisplay.getI18nPath();
-
-			redirect = redirect.substring(i18nPath.length());
 		}
 		else {
 			if (PropsValues.LOCALE_PREPEND_FRIENDLY_URL_STYLE == 0) {

--- a/portal-impl/src/com/liferay/portal/action/UpdateLanguageAction.java
+++ b/portal-impl/src/com/liferay/portal/action/UpdateLanguageAction.java
@@ -118,13 +118,13 @@ public class UpdateLanguageAction implements Action {
 		if (themeDisplay.isI18n()) {
 			String i18nPath = themeDisplay.getI18nPath();
 
-			layoutURL = redirect.substring(i18nPath.length());
+			layoutURL = layoutURL.substring(i18nPath.length());
 		}
 
 		Layout layout = themeDisplay.getLayout();
 
 		if (isFriendlyURLResolver(layoutURL)) {
-			redirect = layoutURL;
+			redirect = layoutURL + friendlyURLSeparatorPart;
 		}
 		else if (layoutURL.equals(StringPool.SLASH) ||
 				 isGroupFriendlyURL(
@@ -139,9 +139,13 @@ public class UpdateLanguageAction implements Action {
 			}
 
 			if (!redirect.endsWith(StringPool.SLASH) &&
-				!queryString.startsWith(StringPool.SLASH)) {
+				!friendlyURLSeparatorPart.startsWith(StringPool.SLASH)) {
 
 				redirect += StringPool.SLASH;
+			}
+
+			if (Validator.isNotNull(friendlyURLSeparatorPart)) {
+				redirect += friendlyURLSeparatorPart;
 			}
 		}
 		else if (layout.isTypeControlPanel() && themeDisplay.isI18n()) {


### PR DESCRIPTION
Hi @dacousalr, 

This issue was reported by a customer. The solution is based on splitting the old variable `queryString` into two variables, one that includes the part of the url containing the friendly-url separator (`/-/`), and the other containing anything after the question-mark character (`?`) if present. (With this change, `queryString` respects the semantics of the HTTP standard.) 

Please let me know if you have any questions. Thanks!