### PR TITLE
LPS-106759 Unable to move Web Contents while display style is card

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/ManagementToolbarDefaultEventHandler.es.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/ManagementToolbarDefaultEventHandler.es.js
@@ -87,7 +87,11 @@ class ManagementToolbarDefaultEventHandler extends DefaultEventHandler {
 	moveEntries() {
 		let moveEntriesURL = this.moveEntriesURL;
 
-		const entrySelectorNodes = document.querySelectorAll('.entry-selector');
+		let entrySelectorNodes = document.querySelectorAll('.entry-selector');
+
+		if (entrySelectorNodes.length === 0){
+			entrySelectorNodes = document.querySelectorAll('.custom-control-input');
+		}
 
 		entrySelectorNodes.forEach(node => {
 			if (node.checked) {


### PR DESCRIPTION
Hi,

Could you review?

The html element's class is changing from entry-selector to custom-control-input when we change to cards view. So this is why the original logic did not work.

Thanks,
László