### PR TITLE
[TS] LPS-92704

### DIFF
--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/util/SitemapImpl.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/util/SitemapImpl.java
@@ -184,62 +184,13 @@ public class SitemapImpl implements Sitemap {
 			ThemeDisplay themeDisplay)
 		throws PortalException {
 
-		Document document = _saxReader.createDocument();
-
-		document.setXMLEncoding(StringPool.UTF8);
-
-		Element rootElement = null;
-
 		if (Validator.isNull(layoutUuid) &&
 			PropsValues.XML_SITEMAP_INDEX_ENABLED) {
 
-			rootElement = document.addElement(
-				"sitemapindex", "http://www.sitemaps.org/schemas/sitemap/0.9");
-		}
-		else {
-			rootElement = document.addElement(
-				"urlset", "http://www.sitemaps.org/schemas/sitemap/0.9");
-
-			rootElement.addAttribute(
-				"xmlns:xsi", "http://www.w3.org/2001/XMLSchema-instance");
-			rootElement.addAttribute(
-				"xsi:schemaLocation",
-				"http://www.w3.org/1999/xhtml " +
-					"http://www.w3.org/2002/08/xhtml/xhtml1-strict.xsd");
+			return _getSitemapIndex(groupId, privateLayout, themeDisplay);
 		}
 
-		rootElement.addAttribute("xmlns:xhtml", "http://www.w3.org/1999/xhtml");
-
-		LayoutSet layoutSet = _layoutSetLocalService.getLayoutSet(
-			groupId, privateLayout);
-
-		if (Validator.isNull(layoutUuid) &&
-			PropsValues.XML_SITEMAP_INDEX_ENABLED) {
-
-			visitLayoutSet(rootElement, layoutSet, themeDisplay);
-
-			return document.asXML();
-		}
-
-		List<SitemapURLProvider> sitemapURLProviders =
-			SitemapURLProviderRegistryUtil.getSitemapURLProviders();
-
-		for (SitemapURLProvider sitemapURLProvider : sitemapURLProviders) {
-			if (Validator.isNull(layoutUuid)) {
-				sitemapURLProvider.visitLayoutSet(
-					rootElement, layoutSet, themeDisplay);
-			}
-			else {
-				sitemapURLProvider.visitLayout(
-					rootElement, layoutUuid, layoutSet, themeDisplay);
-			}
-		}
-
-		if (!rootElement.hasContent()) {
-			return StringPool.BLANK;
-		}
-
-		return document.asXML();
+		return _getSitemap(layoutUuid, groupId, privateLayout, themeDisplay);
 	}
 
 	protected void visitLayoutSet(
@@ -301,6 +252,72 @@ public class SitemapImpl implements Sitemap {
 				locationElement.addText(sb.toString());
 			}
 		}
+	}
+
+	private String _getSitemap(
+			String layoutUuid, long groupId, boolean privateLayout,
+			ThemeDisplay themeDisplay)
+		throws PortalException {
+
+		Document document = _saxReader.createDocument();
+
+		document.setXMLEncoding(StringPool.UTF8);
+
+		Element rootElement = document.addElement(
+			"urlset", "http://www.sitemaps.org/schemas/sitemap/0.9");
+
+		rootElement.addAttribute(
+			"xmlns:xsi", "http://www.w3.org/2001/XMLSchema-instance");
+		rootElement.addAttribute(
+			"xsi:schemaLocation",
+			"http://www.w3.org/1999/xhtml " +
+				"http://www.w3.org/2002/08/xhtml/xhtml1-strict.xsd");
+
+		rootElement.addAttribute("xmlns:xhtml", "http://www.w3.org/1999/xhtml");
+
+		LayoutSet layoutSet = _layoutSetLocalService.getLayoutSet(
+			groupId, privateLayout);
+
+		List<SitemapURLProvider> sitemapURLProviders =
+			SitemapURLProviderRegistryUtil.getSitemapURLProviders();
+
+		for (SitemapURLProvider sitemapURLProvider : sitemapURLProviders) {
+			if (Validator.isNull(layoutUuid)) {
+				sitemapURLProvider.visitLayoutSet(
+					rootElement, layoutSet, themeDisplay);
+			}
+			else {
+				sitemapURLProvider.visitLayout(
+					rootElement, layoutUuid, layoutSet, themeDisplay);
+			}
+		}
+
+		if (!rootElement.hasContent()) {
+			return StringPool.BLANK;
+		}
+
+		return document.asXML();
+	}
+
+	private String _getSitemapIndex(
+			long groupId, boolean privateLayout, ThemeDisplay themeDisplay)
+		throws PortalException {
+
+		Document document = _saxReader.createDocument();
+
+		document.setXMLEncoding(StringPool.UTF8);
+
+		Element rootElement = document.addElement(
+			"sitemapindex", "http://www.sitemaps.org/schemas/sitemap/0.9");
+
+		rootElement.addAttribute("xmlns:xhtml", "http://www.w3.org/1999/xhtml");
+
+		LayoutSet layoutSet = _layoutSetLocalService.getLayoutSet(
+			groupId, privateLayout);
+
+		visitLayoutSet(rootElement, layoutSet, themeDisplay);
+
+		return document.asXML();
 	}
 
 	@Reference

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/util/SitemapImpl.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/util/SitemapImpl.java
@@ -21,6 +21,8 @@ import com.liferay.layout.admin.kernel.util.SitemapURLProviderRegistryUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.model.LayoutTypeController;
@@ -32,8 +34,10 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.TextFormatter;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.xml.Attribute;
 import com.liferay.portal.kernel.xml.Document;
 import com.liferay.portal.kernel.xml.Element;
 import com.liferay.portal.kernel.xml.SAXReader;
@@ -153,6 +157,8 @@ public class SitemapImpl implements Sitemap {
 			alternateURLElement.addAttribute("hreflang", "x-default");
 			alternateURLElement.addAttribute("href", canonicalURL);
 		}
+
+		_removeOldestElementIfNeeded(element, urlElement);
 	}
 
 	@Override
@@ -250,8 +256,18 @@ public class SitemapImpl implements Sitemap {
 				sb.append(layout.isPrivateLayout());
 
 				locationElement.addText(sb.toString());
+
+				_removeOldestElementIfNeeded(element, sitemapElement);
 			}
 		}
+	}
+
+	private int _getElementSize(Element element) {
+		String string = element.asXML();
+
+		byte[] bytes = string.getBytes();
+
+		return bytes.length;
 	}
 
 	private String _getSitemap(
@@ -275,6 +291,8 @@ public class SitemapImpl implements Sitemap {
 
 		rootElement.addAttribute("xmlns:xhtml", "http://www.w3.org/1999/xhtml");
 
+		_initSizeAndEntries(rootElement);
+
 		LayoutSet layoutSet = _layoutSetLocalService.getLayoutSet(
 			groupId, privateLayout);
 
@@ -296,6 +314,8 @@ public class SitemapImpl implements Sitemap {
 			return StringPool.BLANK;
 		}
 
+		_removeEntriesAndSize(rootElement);
+
 		return document.asXML();
 	}
 
@@ -312,13 +332,98 @@ public class SitemapImpl implements Sitemap {
 
 		rootElement.addAttribute("xmlns:xhtml", "http://www.w3.org/1999/xhtml");
 
+		_initSizeAndEntries(rootElement);
+
 		LayoutSet layoutSet = _layoutSetLocalService.getLayoutSet(
 			groupId, privateLayout);
 
 		visitLayoutSet(rootElement, layoutSet, themeDisplay);
 
+		_removeEntriesAndSize(rootElement);
+
 		return document.asXML();
 	}
+
+	private void _initSizeAndEntries(Element rootElement) {
+		int size = _getElementSize(rootElement);
+
+		rootElement.addAttribute(_SIZE, String.valueOf(size));
+
+		rootElement.addAttribute(_ENTRIES, "0");
+	}
+
+	private void _removeEntriesAndSize(Element rootElement) {
+		Attribute entriesAttribute = rootElement.attribute(_ENTRIES);
+		Attribute sizeAttribute = rootElement.attribute(_SIZE);
+
+		if (_log.isDebugEnabled()) {
+			StringBundler sb = new StringBundler(5);
+
+			sb.append("Created site map of ");
+
+			if (entriesAttribute != null) {
+				sb.append(entriesAttribute.getValue());
+				sb.append(" entries and ");
+			}
+
+			if (sizeAttribute != null) {
+				int size = GetterUtil.getInteger(sizeAttribute.getValue());
+
+				sb.append(
+					TextFormatter.formatStorageSize(
+						size, LocaleUtil.fromLanguageId("en_US")));
+
+				sb.append("of size");
+			}
+
+			_log.debug(sb.toString());
+		}
+
+		if (entriesAttribute != null) {
+			rootElement.remove(entriesAttribute);
+		}
+
+		if (sizeAttribute != null) {
+			rootElement.remove(sizeAttribute);
+		}
+	}
+
+	private void _removeOldestElementIfNeeded(
+		Element rootElement, Element newElement) {
+
+		int entries = GetterUtil.getInteger(
+			rootElement.attributeValue(_ENTRIES));
+		int size = GetterUtil.getInteger(rootElement.attributeValue(_SIZE));
+
+		entries++;
+		size += _getElementSize(newElement);
+
+		while ((entries >= _MAXIMUM_NUMBER_OF_ENTRIES) ||
+			   (size >= _MAXIMUM_SIZE_IN_BYTES)) {
+
+			Element oldestUrlElement = rootElement.element(
+				newElement.getName());
+
+			entries--;
+			size -= _getElementSize(oldestUrlElement);
+
+			rootElement.remove(oldestUrlElement);
+		}
+
+		rootElement.addAttribute(_ENTRIES, String.valueOf(entries));
+		rootElement.addAttribute(_SIZE, String.valueOf(size));
+	}
+
+	private static final String _ENTRIES = "entries";
+
+	private static final int _MAXIMUM_NUMBER_OF_ENTRIES = 50000;
+
+	private static final int _MAXIMUM_SIZE_IN_BYTES = 50 * 1024 * 1024;
+
+	private static final String _SIZE = "size";
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		SitemapImpl.class.getName());
 
 	@Reference
 	private LayoutLocalService _layoutLocalService;

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/util/SitemapImpl.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/util/SitemapImpl.java
@@ -21,6 +21,7 @@ import com.liferay.layout.admin.kernel.util.SitemapURLProviderRegistryUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Layout;
@@ -50,6 +51,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -267,7 +269,21 @@ public class SitemapImpl implements Sitemap {
 
 		byte[] bytes = string.getBytes();
 
-		return bytes.length;
+		int offset = 0;
+
+		String name = element.getName();
+
+		if (name.equals("url")) {
+			Set<Locale> availableLocales = LanguageUtil.getAvailableLocales();
+
+			int availableLocalesSize = availableLocales.size();
+
+			offset = availableLocalesSize * _XHTML_ATTRIBUTE.length;
+
+			offset += _XMLNS_ATTRIBUTE.length;
+		}
+
+		return bytes.length - offset;
 	}
 
 	private String _getSitemap(
@@ -421,6 +437,12 @@ public class SitemapImpl implements Sitemap {
 	private static final int _MAXIMUM_SIZE_IN_BYTES = 50 * 1024 * 1024;
 
 	private static final String _SIZE = "size";
+
+	private static final byte[] _XHTML_ATTRIBUTE =
+		" xmlns:xhtml=\"http://www.w3.org/1999/xhtml\"".getBytes();
+
+	private static final byte[] _XMLNS_ATTRIBUTE =
+		" xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\"".getBytes();
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		SitemapImpl.class.getName());


### PR DESCRIPTION
Hi @dacousalr ,

I've separated the creation logic for a sitemap and a sitemapindex branch for better readability.

As we discussed, we aim to limit the output xml to have a maximum of 50k entries or 50MB of size, whichever is reached first. With the added extra that this search is a moving window , which will only show the last limited part of the result set, having the newest ones on the end.

Sitemapindex creation can easily reach 50k entries before 50MB of size, but the sitemap path reaches the size constraint first Needed to adjust the size calculation as the final document.asXML() call will remove various xsd references from the individual entries. (Realised this when the result only had ~22k entries and 37MB in size, with this adjustment the result reached 48.9MB in my test)

While the sitemapindex scenario can be verified with the groovy script on the LPS ticket, for the sitemap scenario, we need to create JournalArticles and set them to be displayed on a target page to reach one of the limitations.

Can you please review?
https://issues.liferay.com/browse/LPS-92704

Thanks,
Balázs