### PR TITLE
LPS-108793 urlTitle is not need for sturctures

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -5592,7 +5592,10 @@ public class JournalArticleLocalServiceImpl
 
 		String urlTitle = urlTitleMap.get(LocaleUtil.toLanguageId(locale));
 
-		if (Validator.isNull(urlTitle)) {
+		if (Validator.isNull(urlTitle) &&
+			(classNameLocalService.getClassNameId(DDMStructure.class) !=
+				article.getClassNameId())) {
+
 			throw new ArticleFriendlyURLException();
 		}
 


### PR DESCRIPTION
hi @dacousalr,
I re-implemented the bugfix from: 
https://issues.liferay.com/browse/LPS-88437
It was probably removed by mistake when implementing a new future in:
https://issues.liferay.com/browse/LPS-97269

https://issues.liferay.com/browse/LPS-108793

Greeting
Attila