### PR TITLE
LPS-110376 Inactive sites returns proper 404 error

### DIFF
--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/servlet/FriendlyURLServlet.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/servlet/FriendlyURLServlet.java
@@ -40,6 +40,7 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextFactory;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.servlet.InactiveRequestHandler;
 import com.liferay.portal.kernel.servlet.PortalMessages;
 import com.liferay.portal.kernel.servlet.ServletContextPool;
 import com.liferay.portal.kernel.servlet.SessionMessages;
@@ -125,7 +126,10 @@ public class FriendlyURLServlet extends HttpServlet {
 			}
 		}
 
-		if (group == null) {
+		if ((group == null) ||
+			(!group.isActive() &&
+			 !inactiveRequestHandler.isShowInactiveRequestMessageEnabled())) {
+
 			StringBundler sb = new StringBundler(5);
 
 			sb.append("{companyId=");
@@ -607,6 +611,9 @@ public class FriendlyURLServlet extends HttpServlet {
 
 	@Reference
 	protected GroupLocalService groupLocalService;
+
+	@Reference
+	protected InactiveRequestHandler inactiveRequestHandler;
 
 	@Reference
 	protected LayoutFriendlyURLLocalService layoutFriendlyURLLocalService;

--- a/modules/apps/portal/portal-inactive-request-handler/src/main/java/com/liferay/portal/inactive/request/handler/internal/InactiveRequestHandlerImpl.java
+++ b/modules/apps/portal/portal-inactive-request-handler/src/main/java/com/liferay/portal/inactive/request/handler/internal/InactiveRequestHandlerImpl.java
@@ -55,6 +55,11 @@ import org.osgi.service.component.annotations.Reference;
 public class InactiveRequestHandlerImpl implements InactiveRequestHandler {
 
 	@Override
+	public boolean isShowInactiveRequestMessageEnabled() {
+		return _showInactiveRequestMessage;
+	}
+
+	@Override
 	public void processInactiveRequest(
 			HttpServletRequest httpServletRequest,
 			HttpServletResponse httpServletResponse, String messageKey)

--- a/portal-kernel/src/com/liferay/portal/kernel/servlet/InactiveRequestHandler.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/servlet/InactiveRequestHandler.java
@@ -27,6 +27,8 @@ import org.osgi.annotation.versioning.ProviderType;
 @ProviderType
 public interface InactiveRequestHandler {
 
+	public boolean isShowInactiveRequestMessageEnabled();
+
 	public void processInactiveRequest(
 			HttpServletRequest httpServletRequest,
 			HttpServletResponse httpServletResponse, String messageKey)


### PR DESCRIPTION
hi @dacousalr,
I implemented a solution based on https://issues.liferay.com/browse/PTR-1575.
There was a previous attempt to fix this issue: LPS-84414, but it produced LPS-84695 as regression. This solution does not have this regression.
Could you review it?
In the previous one there was a naming convention error sorry about that.

https://issues.liferay.com/browse/LPS-110376
Best,
Attila