### PR TITLE
LPS-108211 Do not restrict to layouts with classNameId being 0

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/util/JournalArticleSitemapURLProvider.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/util/JournalArticleSitemapURLProvider.java
@@ -27,6 +27,8 @@ import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.dao.orm.Property;
 import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
@@ -126,11 +128,18 @@ public class JournalArticleSitemapURLProvider implements SitemapURLProvider {
 		for (AssetDisplayPageEntry assetDisplayPageEntry :
 				assetDisplayPageEntries) {
 
-			JournalArticle journalArticle =
-				_journalArticleService.getLatestArticle(
-					assetDisplayPageEntry.getClassPK());
+			try {
+				JournalArticle journalArticle =
+					_journalArticleService.getLatestArticle(
+						assetDisplayPageEntry.getClassPK());
 
-			journalArticles.add(journalArticle);
+				journalArticles.add(journalArticle);
+			}
+			catch (Exception exception) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(exception, exception);
+				}
+			}
 		}
 
 		return journalArticles;
@@ -224,6 +233,9 @@ public class JournalArticleSitemapURLProvider implements SitemapURLProvider {
 			processedArticleIds.add(journalArticle.getArticleId());
 		}
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		JournalArticleSitemapURLProvider.class);
 
 	@Reference
 	private AssetDisplayPageEntryLocalService

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/util/JournalArticleSitemapURLProvider.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/util/JournalArticleSitemapURLProvider.java
@@ -22,7 +22,6 @@ import com.liferay.journal.service.JournalArticleService;
 import com.liferay.layout.admin.kernel.util.Sitemap;
 import com.liferay.layout.admin.kernel.util.SitemapURLProvider;
 import com.liferay.petra.string.StringBundler;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.dao.orm.Property;
 import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
@@ -36,6 +35,7 @@ import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.LayoutSetLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.kernel.xml.Element;
 
@@ -187,7 +187,7 @@ public class JournalArticleSitemapURLProvider implements SitemapURLProvider {
 
 			Layout layout = null;
 
-			if (!journalArticleLayoutUuid.equals(StringPool.BLANK)) {
+			if (Validator.isNotNull(journalArticleLayoutUuid)) {
 				layout = _layoutLocalService.fetchLayoutByUuidAndGroupId(
 					journalArticleLayoutUuid, layoutSet.getGroupId(),
 					layoutSet.isPrivateLayout());

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/util/LayoutSitemapURLProvider.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/util/LayoutSitemapURLProvider.java
@@ -57,6 +57,10 @@ public class LayoutSitemapURLProvider implements SitemapURLProvider {
 		Layout layout = _layoutLocalService.getLayoutByUuidAndGroupId(
 			layoutUuid, layoutSet.getGroupId(), layoutSet.isPrivateLayout());
 
+		if (layout.isTypeAssetDisplay()) {
+			return;
+		}
+
 		visitLayout(element, layout, themeDisplay);
 	}
 
@@ -94,6 +98,10 @@ public class LayoutSitemapURLProvider implements SitemapURLProvider {
 	protected void visitLayout(
 			Element element, Layout layout, ThemeDisplay themeDisplay)
 		throws PortalException {
+
+		if (layout.isTypeAssetDisplay()) {
+			return;
+		}
 
 		UnicodeProperties typeSettingsUnicodeProperties =
 			layout.getTypeSettingsProperties();

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/util/SitemapImpl.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/util/SitemapImpl.java
@@ -264,7 +264,7 @@ public class SitemapImpl implements Sitemap {
 				continue;
 			}
 
-			List<Layout> layouts = _layoutLocalService.getLayouts(
+			List<Layout> layouts = _layoutLocalService.getAllLayouts(
 				layoutSet.getGroupId(), layoutSet.isPrivateLayout(),
 				entry.getKey());
 

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-display-page/src/main/java/com/liferay/layout/type/controller/display/page/internal/layout/type/controller/DisplayPageLayoutTypeController.java
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-display-page/src/main/java/com/liferay/layout/type/controller/display/page/internal/layout/type/controller/DisplayPageLayoutTypeController.java
@@ -236,7 +236,7 @@ public class DisplayPageLayoutTypeController
 
 	@Override
 	public boolean isSitemapable() {
-		return false;
+		return true;
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceImpl.java
@@ -1192,17 +1192,17 @@ public class LayoutLocalServiceImpl extends LayoutLocalServiceBaseImpl {
 
 		DynamicQuery dynamicQuery = layoutLocalService.dynamicQuery();
 
-		Property classNameIdProperty =
-			PropertyFactoryUtil.forName("classNameId");
+		Property classNameIdProperty = PropertyFactoryUtil.forName(
+			"classNameId");
 
-		dynamicQuery.add(classNameIdProperty.eq(new Long(0)));
+		dynamicQuery.add(classNameIdProperty.eq(Long.valueOf(0)));
 
 		Property groupIdProperty = PropertyFactoryUtil.forName("groupId");
 
 		dynamicQuery.add(groupIdProperty.eq(groupId));
 
-		Property privateLayoutProperty =
-			PropertyFactoryUtil.forName("privateLayout");
+		Property privateLayoutProperty = PropertyFactoryUtil.forName(
+			"privateLayout");
 
 		dynamicQuery.add(privateLayoutProperty.eq(privateLayout));
 

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceImpl.java
@@ -1192,11 +1192,6 @@ public class LayoutLocalServiceImpl extends LayoutLocalServiceBaseImpl {
 
 		DynamicQuery dynamicQuery = layoutLocalService.dynamicQuery();
 
-		Property classNameIdProperty = PropertyFactoryUtil.forName(
-			"classNameId");
-
-		dynamicQuery.add(classNameIdProperty.eq(Long.valueOf(0)));
-
 		Property groupIdProperty = PropertyFactoryUtil.forName("groupId");
 
 		dynamicQuery.add(groupIdProperty.eq(groupId));

--- a/portal-kernel/src/com/liferay/portal/kernel/service/LayoutLocalService.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/LayoutLocalService.java
@@ -725,6 +725,22 @@ public interface LayoutLocalService
 	public ActionableDynamicQuery getActionableDynamicQuery();
 
 	/**
+	 * Returns all the layouts that match the type and belong to the group,
+	 * including the ones marked as System.
+	 *
+	 * @param groupId the primary key of the group
+	 * @param privateLayout whether the layout is private to the group
+	 * @param type the type of the layouts (optiona.lly {@link
+	 LayoutConstants#TYPE_PORTLET})
+	 * @return the matching layouts, or an empty list if no matches were
+	 found
+	 */
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public List<Layout> getAllLayouts(
+			long groupId, boolean privateLayout, String type)
+		throws PortalException;
+
+	/**
 	 * Returns the primary key of the default layout for the group.
 	 *
 	 * @param groupId the primary key of the group

--- a/portal-kernel/src/com/liferay/portal/kernel/service/LayoutLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/LayoutLocalServiceUtil.java
@@ -828,6 +828,24 @@ public class LayoutLocalServiceUtil {
 	}
 
 	/**
+	 * Returns all the layouts that match the type and belong to the group,
+	 * including the ones marked as System.
+	 *
+	 * @param groupId the primary key of the group
+	 * @param privateLayout whether the layout is private to the group
+	 * @param type the type of the layouts (optiona.lly {@link
+	 LayoutConstants#TYPE_PORTLET})
+	 * @return the matching layouts, or an empty list if no matches were
+	 found
+	 */
+	public static java.util.List<com.liferay.portal.kernel.model.Layout>
+			getAllLayouts(long groupId, boolean privateLayout, String type)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return getService().getAllLayouts(groupId, privateLayout, type);
+	}
+
+	/**
 	 * Returns the primary key of the default layout for the group.
 	 *
 	 * @param groupId the primary key of the group

--- a/portal-kernel/src/com/liferay/portal/kernel/service/LayoutLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/LayoutLocalServiceWrapper.java
@@ -844,6 +844,25 @@ public class LayoutLocalServiceWrapper
 	}
 
 	/**
+	 * Returns all the layouts that match the type and belong to the group,
+	 * including the ones marked as System.
+	 *
+	 * @param groupId the primary key of the group
+	 * @param privateLayout whether the layout is private to the group
+	 * @param type the type of the layouts (optiona.lly {@link
+	 LayoutConstants#TYPE_PORTLET})
+	 * @return the matching layouts, or an empty list if no matches were
+	 found
+	 */
+	@Override
+	public java.util.List<Layout> getAllLayouts(
+			long groupId, boolean privateLayout, String type)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _layoutLocalService.getAllLayouts(groupId, privateLayout, type);
+	}
+
+	/**
 	 * Returns the primary key of the default layout for the group.
 	 *
 	 * @param groupId the primary key of the group


### PR DESCRIPTION
Hey @dacousalr 

I added a commit that removed the condition that classNameId has to be 0 as there may be Layouts needed to be represented on the sitemap whose classNameId might not be 0.

However, an interesting thing is that when a Display Page Template is created, two Layouts with asset_display type are created in the database:

1. a Layout with classNameId 0 and with status 2 (draft)
2. a Layout with a classNameId corresponding to com.liferay.portal.kernel.model.Layout and status 0 (published)

Is this an intended behavior?

Thank you and best regards,
István