### PR TITLE
LPS-110937 Sites created from Content Page Templates are not present in sitemap.xml

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceImpl.java
@@ -1204,7 +1204,14 @@ public class LayoutLocalServiceImpl extends LayoutLocalServiceBaseImpl {
 		Property classNameIdProperty = PropertyFactoryUtil.forName(
 			"classNameId");
 
-		dynamicQuery.add(classNameIdProperty.eq(Long.valueOf(0)));
+		long layoutPageTemplateEntryClassNameId =
+			classNameLocalService.getClassNameId(
+				_LAYOT_PAGE_TEMPLATE_ENTRY_CLASS_NAME);
+
+		dynamicQuery.add(
+			RestrictionsFactoryUtil.or(
+				classNameIdProperty.eq(Long.valueOf(0)),
+				classNameIdProperty.eq(layoutPageTemplateEntryClassNameId)));
 
 		Property typeProperty = PropertyFactoryUtil.forName("type");
 
@@ -3838,6 +3845,9 @@ public class LayoutLocalServiceImpl extends LayoutLocalServiceBaseImpl {
 				CustomizedPages.namespacePlid(layout.getPlid()));
 		}
 	}
+
+	private static final String _LAYOT_PAGE_TEMPLATE_ENTRY_CLASS_NAME =
+		"com.liferay.layout.page.template.model.LayoutPageTemplateEntry";
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		LayoutLocalServiceImpl.class);


### PR DESCRIPTION
Hi @dacousalr 

Since [LPS-108211](https://issues.liferay.com/browse/LPS-108211) is already committed, I created a regression ticket [LPS-110937](https://issues.liferay.com/browse/LPS-110937).
This handles the case where `classNameId == classNameLocalService.getClassNameId("com.liferay.layout.page.template.model.LayoutPageTemplateEntry")`

These Layouts won't be "drafts" as such Layout's `classNameId == classNameLocalService.getClassNameId("com.liferay.layout.page.template.model.Layout")`

Could you please check this solution?

Thank you and best regards,
István