### PR TITLE
[TS] LPS-112207 iframe-web: Use escapeJS instead

### DIFF
--- a/modules/apps/iframe/iframe-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/iframe/iframe-web/src/main/resources/META-INF/resources/view.jsp
@@ -164,7 +164,7 @@
 	if (iframe) {
 		iframe.set(
 			'src',
-			'<%= HtmlUtil.escapeHREF(iFrameDisplayContext.getIframeSrc()) %>'
+			'<%= HtmlUtil.escapeJS(iFrameDisplayContext.getIframeSrc()) %>'
 		);
 
 		iframe.plug(A.Plugin.AutosizeIframe, {
@@ -204,7 +204,7 @@
 		);
 
 		Liferay.Util.fetch(
-			'<%= HtmlUtil.escapeHREF(iFrameDisplayContext.getIframeSrc()) %>',
+			'<%= HtmlUtil.escapeJS(iFrameDisplayContext.getIframeSrc()) %>',
 			{
 				headers: headers,
 				mode: 'no-cors',


### PR DESCRIPTION
Hi @dacousalr ,

**Context**
The Iframe widget is currently escaping the URL incorrectly, which results in URL parameters being lost.

**Issue:** 
The **&** is being escaped to **&amp\;** when crafting the URL. Using escapeJS instead of escapeHREF resolves the issue.

If I should send this to another reviewer, please let me know.

Feel free to let me know if you have any questions.
Thanks!