### PR TITLE
LPS-110894 Giving edit permission on an individual Content Page doesn't work

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
@@ -520,13 +520,15 @@ public class ContentPageEditorDisplayContext {
 
 		List<Map<String, Object>> sidebarPanels = new ArrayList<>();
 
+		Layout publishedLayout = _getPublishedLayout();
+
 		for (ContentPageEditorSidebarPanel contentPageEditorSidebarPanel :
 				_contentPageEditorSidebarPanels) {
 
 			if (!contentPageEditorSidebarPanel.isVisible(pageIsDisplayPage) ||
 				!contentPageEditorSidebarPanel.isVisible(
-					themeDisplay.getPermissionChecker(), themeDisplay.getPlid(),
-					pageIsDisplayPage)) {
+					themeDisplay.getPermissionChecker(),
+					publishedLayout.getPlid(), pageIsDisplayPage)) {
 
 				continue;
 			}

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-content/src/main/java/com/liferay/layout/type/controller/content/internal/layout/type/controller/ContentLayoutTypeController.java
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-content/src/main/java/com/liferay/layout/type/controller/content/internal/layout/type/controller/ContentLayoutTypeController.java
@@ -85,14 +85,13 @@ public class ContentLayoutTypeController extends BaseLayoutTypeControllerImpl {
 			HttpServletResponse httpServletResponse, Layout layout)
 		throws Exception {
 
+		Layout curLayout = _layoutLocalService.fetchLayout(layout.getClassPK());
+
 		ThemeDisplay themeDisplay =
 			(ThemeDisplay)httpServletRequest.getAttribute(
 				WebKeys.THEME_DISPLAY);
 
 		if (layout.getClassNameId() == _portal.getClassNameId(Layout.class)) {
-			Layout curLayout = _layoutLocalService.fetchLayout(
-				layout.getClassPK());
-
 			if (curLayout.isPending()) {
 				curLayout = layout;
 			}
@@ -111,7 +110,7 @@ public class ContentLayoutTypeController extends BaseLayoutTypeControllerImpl {
 
 		if (layoutMode.equals(Constants.EDIT) &&
 			!_hasUpdatePermissions(
-				themeDisplay.getPermissionChecker(), layout)) {
+				themeDisplay.getPermissionChecker(), curLayout)) {
 
 			layoutMode = Constants.VIEW;
 		}


### PR DESCRIPTION
[LPS-110894](https://issues.liferay.com/browse/LPS-110894)

Hi Daniel,

I hope you can review my changes.

In short, there is a permission checking issue when editing content pages. Regular users with update permission on individual content pages are unable to access the page in edit mode. 

The root cause it that content pages has two layout records persisted: published and draft. Granting permissions happens on the published layout, so checking permission should be done on the same.

Thank you,
Istvan