### PR TITLE
[TS] LPS-112702

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
@@ -393,7 +393,8 @@ public class ContentPageEditorDisplayContext {
 			).put(
 				"fragments", _getFragmentCollections(false, true)
 			).put(
-				"languageId", themeDisplay.getLanguageId()
+				"languageId",
+				LocaleUtil.toLanguageId(themeDisplay.getSiteDefaultLocale())
 			).put(
 				"layoutData", JSONFactoryUtil.createJSONObject(_getLayoutData())
 			).put(


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-112702

From @wanderlast:

> A pretty straightforward fix. This causes the content page editor to always start set to the default site language, rather than the user's chosen language. Confirmed [here](https://issues.liferay.com/browse/PTR-1663) by the SME as the behavior that the PT wants.

Sending to you since you are the SME who confirmed the behavior.  If I should send it elsewhere, please let me know, thanks!