### PR TITLE
[TECHNICAL-SUPPORT] LPS-112733 Exporting user segments with expressions containing references

### DIFF
--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/odata/filter/expression/ExportExpressionVisitorImpl.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/odata/filter/expression/ExportExpressionVisitorImpl.java
@@ -16,7 +16,10 @@ package com.liferay.segments.internal.odata.filter.expression;
 
 import com.liferay.expando.kernel.model.ExpandoColumn;
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
+import com.liferay.exportimport.kernel.lar.StagedModelDataHandlerUtil;
 import com.liferay.petra.string.CharPool;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.ClassedModel;
 import com.liferay.portal.kernel.model.StagedModel;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -195,13 +198,23 @@ public class ExportExpressionVisitorImpl implements ExpressionVisitor<Object> {
 			return;
 		}
 
-		Element entityElement = _portletDataContext.getExportDataElement(
-			_stagedModel);
-
-		_portletDataContext.addReferenceElement(
-			_stagedModel, entityElement, classedModel,
-			PortletDataContext.REFERENCE_TYPE_DEPENDENCY, false);
+		try {
+			StagedModelDataHandlerUtil.exportReferenceStagedModel(
+				_portletDataContext, _stagedModel, (StagedModel)classedModel,
+				PortletDataContext.REFERENCE_TYPE_DEPENDENCY);
+		}
+		catch (Exception exception) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					"Unable to export classed model " +
+						classedModel.getModelClassName(),
+					exception);
+			}
+		}
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		ExportExpressionVisitorImpl.class);
 
 	private final Map<String, EntityField> _customFieldEntityFields;
 	private final EntityModel _entityModel;


### PR DESCRIPTION
Hi @dacousalr ,

I changed how references in user segment expressions are added in the export process. Using the standard `exportReferenceStagedModel(..)` staging helper method provides the following:
* When referencing entities outside the site's scope (Organization, Role, Site, Tag (global), User, UserGroup), they are added as "missing-reference".
* When referencing in the site's scope (e.g: Team), then these models are also included in the export.

Please review my changes.

Thanks,
Vendel