### PR TITLE
[TS] LPS-113902 Revert "LPS-68303 avoid double friendly url encoding to support multi-lingual urls", decoding is handled by FriendlyURLNormalizer#normalizeWithEncoding

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceImpl.java
@@ -73,7 +73,6 @@ import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
-import com.liferay.portal.kernel.util.HttpUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
@@ -1350,8 +1349,6 @@ public class LayoutLocalServiceImpl extends LayoutLocalServiceBaseImpl {
 
 			throw new NoSuchLayoutException(sb.toString());
 		}
-
-		friendlyURL = HttpUtil.decodeURL(friendlyURL);
 
 		friendlyURL = layoutLocalServiceHelper.getFriendlyURL(friendlyURL);
 


### PR DESCRIPTION
Hi @dacousalr ,

This case is a bit hard to reproduce, might say it is a legacy data issue. pre-de-85, pages created from page templates are created with double encoded friendlyURLs, which don't work if it has to go through both decodings in LayoutLocalServiceImpl#getFriendlyURLLayout and at FriendlyURLNormalizerImpl#normalizeWithEncoding.
(ends up as a once encoded url, which can't be matched to any db entries)

Can you please review?
https://issues.liferay.com/browse/LPS-113902

Thanks,
Balázs