### PR TITLE
LPS-114116 | Missing 3-dot menu and back arrow in asset publisher if show asset title is disabled

### DIFF
--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view_asset_entry_full_content.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view_asset_entry_full_content.jsp
@@ -67,39 +67,39 @@ Map<String, Object> fragmentsEditorData = HashMapBuilder.<String, Object>put(
 
 <div class="asset-full-content clearfix mb-5 <%= assetPublisherDisplayContext.isDefaultAssetPublisher() ? "default-asset-publisher" : StringPool.BLANK %> <%= assetPublisherDisplayContext.isShowAssetTitle() ? "show-asset-title" : "no-title" %> <%= ((previewClassNameId == assetEntry.getClassNameId()) && (previewClassPK == assetEntry.getClassPK())) ? "p-1 preview-asset-entry" : StringPool.BLANK %>" <%= AUIUtil.buildData(fragmentsEditorData) %>>
 	<div class="mb-2">
-		<c:if test="<%= assetPublisherDisplayContext.isShowAssetTitle() %>">
-			<h4 class="component-title">
-				<c:if test="<%= showBackURL && Validator.isNotNull(redirect) %>">
-					<liferay-ui:icon
-						cssClass="header-back-to"
-						icon="angle-left"
-						markupView="lexicon"
-						url="<%= redirect %>"
-					/>
-				</c:if>
+		<h4 class="component-title">
+			<c:if test="<%= showBackURL && Validator.isNotNull(redirect) %>">
+				<liferay-ui:icon
+					cssClass="header-back-to"
+					icon="angle-left"
+					markupView="lexicon"
+					url="<%= redirect %>"
+				/>
+			</c:if>
 
+			<c:if test="<%= assetPublisherDisplayContext.isShowAssetTitle() %>">
 				<span class="asset-title d-inline">
 					<%= HtmlUtil.escape(title) %>
 				</span>
+			</c:if>
 
-				<c:if test="<%= !print %>">
+			<c:if test="<%= !print %>">
 
-					<%
-					String fullContentRedirect = currentURL;
+				<%
+				String fullContentRedirect = currentURL;
 
-					if (WorkflowDefinitionLinkLocalServiceUtil.hasWorkflowDefinitionLink(assetEntry.getCompanyId(), assetEntry.getGroupId(), assetEntry.getClassName())) {
-						fullContentRedirect = redirect;
-					}
+				if (WorkflowDefinitionLinkLocalServiceUtil.hasWorkflowDefinitionLink(assetEntry.getCompanyId(), assetEntry.getGroupId(), assetEntry.getClassName())) {
+					fullContentRedirect = redirect;
+				}
 
-					request.setAttribute("view.jsp-fullContentRedirect", fullContentRedirect);
-					%>
+				request.setAttribute("view.jsp-fullContentRedirect", fullContentRedirect);
+				%>
 
-					<span class="d-inline-flex">
-						<liferay-util:include page="/asset_actions.jsp" servletContext="<%= application %>" />
-					</span>
-				</c:if>
-			</h4>
-		</c:if>
+				<span class="d-inline-flex">
+					<liferay-util:include page="/asset_actions.jsp" servletContext="<%= application %>" />
+				</span>
+			</c:if>
+		</h4>
 	</div>
 
 	<span class="asset-anchor lfr-asset-anchor" id="<%= assetEntry.getEntryId() %>"></span>


### PR DESCRIPTION
Hi @dacousalr, 

This issue was reported by a customer in 7.2. 

Both `master` and `7.2.x` have the same behavior: if Show Asset Title is disabled, both the 3-dot menu and the back arrow will be missing. In `7.1.x` and `7.0.x` the 3-dot menu will be visible but the back arrow will be missing. 

Relevant past commits: 92e1a120 ([LPS-65442](https://issues.liferay.com/browse/LPS-65442)) and cc7c380a ([LPS-93184](https://issues.liferay.com/browse/LPS-93184)). 

It seems that the back arrow is more attached to the asset title but in my opinion it should not be. 

Please let me know if you have any questions. Thanks!