### PR TITLE
LPS-114135 Can't delete line-breaks in fragments with one keystroke

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/processors/getAlloyEditorProcessor.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/processors/getAlloyEditorProcessor.js
@@ -156,10 +156,6 @@ export default function getAlloyEditorProcessor(
 						nativeEditor.execCommand('selectAll');
 					}
 				}),
-
-				_stopEventPropagation(element, 'keydown'),
-				_stopEventPropagation(element, 'keyup'),
-				_stopEventPropagation(element, 'keypress'),
 			];
 
 			if (config.undoEnabled) {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/processors/getAlloyEditorProcessor.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/processors/getAlloyEditorProcessor.js
@@ -224,23 +224,6 @@ export default function getAlloyEditorProcessor(
 }
 
 /**
- * Adds a listener to stop the given element event propagation
- * @param {HTMLElement} element
- * @param {string} eventName
- */
-function _stopEventPropagation(element, eventName) {
-	const handler = (event) => event.stopPropagation();
-
-	element.addEventListener(eventName, handler);
-
-	return {
-		removeListener: () => {
-			element.removeEventListener(eventName, handler);
-		},
-	};
-}
-
-/**
  * Place the caret in the click position
  * @param {Event} event
  * @param {CKEditor} nativeEditor


### PR DESCRIPTION
Hey,

[LPS-114135](https://issues.liferay.com/browse/LPS-114135)
I don't know what was the original reasoning behind not delegating the key events when the editor is active, but in my tests I did not find any regression.

Pls review the changes.

Thank you,