### PR TITLE
LPS-114484 Order by column preference is lost in Asset Publisher after upgrade unless it is filtered by field

### DIFF
--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/upgrade/v1_0_0/UpgradePortletPreferences.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/upgrade/v1_0_0/UpgradePortletPreferences.java
@@ -46,6 +46,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import javax.portlet.PortletPreferences;
 
@@ -246,8 +248,18 @@ public class UpgradePortletPreferences extends BaseUpgradePortletPreferences {
 			if (values.length == 3) {
 				long structureId = GetterUtil.getLong(values[1]);
 
+				String fieldName = values[2];
+
+				Matcher matcher = _invalidFieldNameCharsPattern.matcher(
+					fieldName);
+
+				if (matcher.find()) {
+					fieldName = fieldName.replaceAll(
+						_INVALID_FIELD_NAME_CHARS_REGEX, StringPool.BLANK);
+				}
+
 				DDMFormField ddmFormField = getDDMFormField(
-					getDDMForm(structureId), values[2]);
+					getDDMForm(structureId), fieldName);
 
 				if ((ddmFormField != null) &&
 					Validator.isNotNull(ddmFormField.getIndexType())) {
@@ -260,7 +272,7 @@ public class UpgradePortletPreferences extends BaseUpgradePortletPreferences {
 					sb.append(_DDM_FIELD_SEPARATOR);
 					sb.append(values[1]);
 					sb.append(_DDM_FIELD_SEPARATOR);
-					sb.append(values[2]);
+					sb.append(fieldName);
 
 					value = sb.toString();
 				}
@@ -316,9 +328,9 @@ public class UpgradePortletPreferences extends BaseUpgradePortletPreferences {
 			else if (journalFilterByFieldEnable) {
 				upgradeJournalDateFieldValue(portletPreferences);
 			}
-
-			upgradeOrderByColumns(portletPreferences);
 		}
+
+		upgradeOrderByColumns(portletPreferences);
 
 		return PortletPreferencesFactoryUtil.toXML(portletPreferences);
 	}
@@ -383,6 +395,9 @@ public class UpgradePortletPreferences extends BaseUpgradePortletPreferences {
 	private static final String _DL_FILTER_BY_FIELD_ENABLED_KEY =
 		"subtypeFieldsFilterEnabledDLFileEntryAssetRendererFactory";
 
+	private static final String _INVALID_FIELD_NAME_CHARS_REGEX =
+		"([\\p{Punct}&&[^_]]|\\p{Space})+";
+
 	private static final String _JOURNAL_CLASS_TYPE =
 		"anyClassTypeJournalArticleAssetRendererFactory";
 
@@ -395,6 +410,8 @@ public class UpgradePortletPreferences extends BaseUpgradePortletPreferences {
 
 	private static final Map<Long, DDMForm> _ddmSructureDDMForms =
 		new HashMap<>();
+	private static final Pattern _invalidFieldNameCharsPattern =
+		Pattern.compile(_INVALID_FIELD_NAME_CHARS_REGEX);
 
 	private final DDMStructureLinkLocalService _ddmStructureLinkLocalService;
 	private final DDMStructureLocalService _ddmStructureLocalService;


### PR DESCRIPTION
Hi @dacousalr ,

Could you review this pull request, please?

You can find more information in [LPS-114484](https://issues.liferay.com/browse/LPS-114484).

In LPS-63404 we introduced the upgrade of this preference, OrderByColumn, but it was only considered in case the option 'Filter by Field' was enable. Per my understanding, I think we should do it always, not only when that option was selected.

The part about the regular expression is just to match the same fields name in DDMStructure, otherwise the fieldName is not found in the form, the preference not updates and the user sees how the configuration was lost.

Thanks.

Regards.