### PR TITLE
LPS-114577

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -8374,10 +8374,7 @@ public class PortalImpl implements Portal {
 						);
 					}
 
-					if (_containsHostname(virtualHostnames, portalDomain) ||
-						PropsValues.VIRTUAL_HOSTS_DEFAULT_SITE_NAME.equals(
-							group.getGroupKey())) {
-
+					if (_containsHostname(virtualHostnames, portalDomain)) {
 						String path = StringPool.BLANK;
 
 						if (themeDisplay.isWidget()) {


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-114577
https://issues.liferay.com/browse/PTR-1721

The logic from `Portal.getVirtualHostNames` will only include the company virtual host under the specific conditions where we'd be willing to acknowledge it, via `LayoutSet.getCompanyFallbackVirtualHostname`, which will check if the layout set corresponds to the `virtual.hosts.default.site.name`.

* https://github.com/liferay/liferay-portal/blob/7.3.2-ga3/portal-impl/src/com/liferay/portal/util/PortalImpl.java#L5909-L5927
* https://github.com/liferay/liferay-portal/blob/7.3.2-ga3/portal-impl/src/com/liferay/portal/model/impl/LayoutSetImpl.java#L78-L104

As a result, the specific scenario that it was intended to handle (allowing us to remove `/web/site-friendly-url` whenever we are visiting the public layout set of the site specified in  `virtual.hosts.default.site.name`) is already handled correctly by the existing `_containsHostname` check, and adding the additional `virtual.hosts.default.site.name` check ends up causing the wrong behavior.