### PR TITLE
LPS-113902 Adding test both for current and legacy friendlyURLs

### DIFF
--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/service/test/LayoutLocalServiceTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/service/test/LayoutLocalServiceTest.java
@@ -17,6 +17,7 @@ package com.liferay.layout.service.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.friendly.url.service.FriendlyURLEntryLocalServiceUtil;
 import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.User;
@@ -25,6 +26,7 @@ import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.HttpUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -124,6 +126,46 @@ public class LayoutLocalServiceTest {
 				_layoutLocalService.getFriendlyURLLayout(
 					_group.getGroupId(), false, "/friendly-url-" + i));
 		}
+	}
+
+	@Test
+	public void testLayoutsAreFoundBasedOnDoubleHttpEncodedLegacyFriendlyURL()
+		throws Exception {
+
+		String name = "café";
+
+		String friendlyURL = HttpUtil.decodeURL(StringPool.SLASH + name);
+
+		friendlyURL = HttpUtil.decodeURL(friendlyURL);
+
+		Layout layout = LayoutTestUtil.addLayout(
+			_group.getGroupId(), false,
+			Collections.singletonMap(LocaleUtil.getDefault(), name),
+			Collections.singletonMap(LocaleUtil.getDefault(), friendlyURL));
+
+		Assert.assertEquals(
+			layout,
+			_layoutLocalService.getFriendlyURLLayout(
+				_group.getGroupId(), false, friendlyURL));
+	}
+
+	@Test
+	public void testLayoutsAreFoundBasedOnHttpEncodedFriendlyURL()
+		throws Exception {
+
+		String name = "café";
+
+		String friendlyURL = HttpUtil.decodeURL(StringPool.SLASH + name);
+
+		Layout layout = LayoutTestUtil.addLayout(
+			_group.getGroupId(), false,
+			Collections.singletonMap(LocaleUtil.getDefault(), name),
+			Collections.singletonMap(LocaleUtil.getDefault(), null));
+
+		Assert.assertEquals(
+			layout,
+			_layoutLocalService.getFriendlyURLLayout(
+				_group.getGroupId(), false, friendlyURL));
 	}
 
 	@Test


### PR DESCRIPTION
Hi @dacousalr ,
In reference of https://github.com/brianchandotcom/liferay-portal/pull/89092#issuecomment-633555481 I've created these 2 basic test cases. 
As we can't reproduce the legacy path creating double encoded friendlyURLs I opted for creating the layout with a particular "user determined" friendlyURL, which is double encoded.
I think these 2 cases are sufficient to cover this case.

Can you please review?
https://issues.liferay.com/browse/LPS-113902

Thanks,
Balázs