### PR TITLE
LPS-114083 Add an underscore to the name before the counter to avoid confusion with existing names with a number at the end

### DIFF
--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v1_1_0/UpgradeLayoutPrototype.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v1_1_0/UpgradeLayoutPrototype.java
@@ -15,6 +15,7 @@
 package com.liferay.layout.page.template.internal.upgrade.v1_1_0;
 
 import com.liferay.layout.page.template.constants.LayoutPageTemplateEntryTypeConstants;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.model.Company;
@@ -96,13 +97,15 @@ public class UpgradeLayoutPrototype extends UpgradeProcess {
 					int i = 1;
 
 					while (true) {
-						name = name + i;
+						String newName = name + StringPool.DASH + i;
 
-						if (existingNames.contains(name)) {
+						if (existingNames.contains(newName)) {
 							i++;
 
 							continue;
 						}
+
+						name = newName;
 
 						break;
 					}

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v1_1_0/UpgradeLayoutPrototype.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v1_1_0/UpgradeLayoutPrototype.java
@@ -93,9 +93,9 @@ public class UpgradeLayoutPrototype extends UpgradeProcess {
 				String name = nameMap.get(defaultLocale);
 
 				if (existingNames.contains(name)) {
-					while (true) {
-						int i = 1;
+					int i = 1;
 
+					while (true) {
 						name = name + i;
 
 						if (existingNames.contains(name)) {

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v1_1_0/UpgradeLayoutPrototype.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v1_1_0/UpgradeLayoutPrototype.java
@@ -30,6 +30,7 @@ import com.liferay.portal.kernel.workflow.WorkflowConstants;
 
 import java.sql.PreparedStatement;
 
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
@@ -74,6 +75,8 @@ public class UpgradeLayoutPrototype extends UpgradeProcess {
 				_layoutPrototypeLocalService.getLayoutPrototypes(
 					QueryUtil.ALL_POS, QueryUtil.ALL_POS);
 
+			List<String> existingNames = new ArrayList<>();
+
 			for (LayoutPrototype layoutPrototype : layoutPrototypes) {
 				Date createDate = layoutPrototype.getCreateDate();
 				String nameXML = layoutPrototype.getName();
@@ -87,6 +90,26 @@ public class UpgradeLayoutPrototype extends UpgradeProcess {
 				Locale defaultLocale = LocaleUtil.fromLanguageId(
 					LocalizationUtil.getDefaultLanguageId(nameXML));
 
+				String name = nameMap.get(defaultLocale);
+
+				if (existingNames.contains(name)) {
+					while (true) {
+						int i = 1;
+
+						name = name + i;
+
+						if (existingNames.contains(name)) {
+							i++;
+
+							continue;
+						}
+
+						break;
+					}
+				}
+
+				existingNames.add(name);
+
 				ps.setString(1, layoutPrototype.getUuid());
 				ps.setLong(2, increment());
 				ps.setLong(3, company.getGroupId());
@@ -96,7 +119,7 @@ public class UpgradeLayoutPrototype extends UpgradeProcess {
 				ps.setDate(7, new java.sql.Date(createDate.getTime()));
 				ps.setDate(8, new java.sql.Date(createDate.getTime()));
 				ps.setLong(9, 0);
-				ps.setString(10, nameMap.get(defaultLocale));
+				ps.setString(10, name);
 				ps.setInt(
 					11, LayoutPageTemplateEntryTypeConstants.TYPE_WIDGET_PAGE);
 				ps.setLong(12, layoutPrototype.getLayoutPrototypeId());


### PR DESCRIPTION
Hi @dacousalr,

I would like to get your opinion about this case. We found a [bug](https://issues.liferay.com/browse/LPS-114083) in the UpgradeLayoutPrototype class when two LayoutPrototypes have the same name for the default locale. In that table that situation is valid, however during the upgrade when we create the LayoutPageTemplateEntry based on that table, we violate the following index because the name is unique by group:
create unique index IX_A075DAA4 on LayoutPageTemplateEntry (groupId, name[$COLUMN_LENGTH:75$]);

To solve it we just add **-X** to the names in case they are repeated. This seems a valid solution because they are related to the LayoutPrototype table through the layoutPrototypeId field. However, we have a question:
- **Should we also update the LayoutPrototypes to the same name (including adding the number to the name for each locale)?**

We are not sure what to do because the upgrade doesn't fail after these changes but we still show the LayoutPrototype.name in the Suite Builder/Page Templates window and it's shown repeated. Taking this into account maybe it makes sense to change it during the upgrade too but the problem won't be solved because right now this is the current behavior in master:
- If you create a new page template with the same name than other for the default locale, it fails (I guess because of the previously mentioned index) but you don't get any information about why either in the browser or logs.
- You can create page templates with the same name in non-default languages.

So, it seems that it's an issue about how the relationship between LayoutPageTemplateEntry and LayoutPrototype has been designed.

Please, let us what you think about this.

Thanks.
cc/ @SamZiemer
