### PR TITLE
[TECHNICAL SUPPORT] LPS-115491 Summary field value is lost when default locale is changed

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
@@ -567,6 +567,13 @@ AUI.add(
 
 					var instanceId = instance.get('instanceId');
 
+					var defaultLanguageId = instance.get('definition')
+						.defaultLanguageId;
+
+					Liferay.fire('ddm:default-locale-sync', {
+						defaultLanguageId,
+					});
+
 					var values = instance.get('values');
 
 					var fieldValue = instance.getFieldInfo(

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/JournalPortlet.es.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/JournalPortlet.es.js
@@ -66,9 +66,16 @@ class JournalPortlet extends PortletBase {
 			);
 		}
 
+		this.defaultLanguageId = themeDisplay.getDefaultLanguageId();
+
 		this._localeChangedHandler = Liferay.after(
 			'inputLocalized:localeChanged',
 			this._onLocaleChange.bind(this)
+		);
+
+		this._localeChangedHandler = Liferay.after(
+			['inputLocalized:defaultLocaleChanged', 'ddm:default-locale-sync'],
+			this._onDeafultLocaleChange.bind(this)
 		);
 
 		this._setupSidebar();
@@ -87,6 +94,7 @@ class JournalPortlet extends PortletBase {
 	detached() {
 		this._eventHandler.removeAllListeners();
 		this._localeChangedHandler.detach();
+		this._onDeafultLocaleChange.detach();
 	}
 
 	/**
@@ -112,11 +120,24 @@ class JournalPortlet extends PortletBase {
 	}
 
 	/**
+	 * Updates defaultLocale
+	 * @param {Event} event
+	 */
+	_onDeafultLocaleChange(event) {
+		if (event.item) {
+			this.defaultLanguageId = event.item.getAttribute('data-value');
+		}
+		else if (event.defaultLanguageId) {
+			this.defaultLanguageId = event.defaultLanguageId;
+		}
+	}
+
+	/**
 	 * Updates description and title values on locale changed
 	 * @param {Event} event
 	 */
 	_onLocaleChange(event) {
-		const defaultLanguageId = themeDisplay.getDefaultLanguageId();
+		const defaultLanguageId = this.defaultLanguageId;
 		const selectedLanguageId = event.item.getAttribute('data-value');
 
 		if (selectedLanguageId) {


### PR DESCRIPTION
Hey,
[LPS-115491](https://issues.liferay.com/browse/LPS-115491),
We do not handle the changeable default language feature inside journal-portlet. I attached a listener to defaultLocaleChange and also created a new event, that I fire from ddm_form.js. This is to sync the defaultLanguage from the structure-definition. It still defaults to the defaultLocale inside the theme-display.

Please review it,

Thanks