### PR TITLE
LPS-116291

### DIFF
--- a/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/view_resources.jsp
+++ b/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/view_resources.jsp
@@ -102,8 +102,6 @@ if (Validator.isNotNull(keywords)) {
 
 	<%
 	String redirectURL = PortalUtil.getLayoutFullURL(layout, themeDisplay);
-
-	redirectURL = HttpUtil.addParameter(redirectURL, "portletResource", portletDisplay.getId());
 	%>
 
 	<liferay-asset:asset-add-button


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-116291

When SPA is enabled, it goes to a URL without a `portletResouce` URL parameter, and so we're updating non-SPA to match.

https://github.com/liferay/liferay-portal/blob/master/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/entries/add_content_icon.jsp#L66-L70

/cc @haubuicodeengine 