### PR TITLE
LPS-117484 Creating a Web Content with a '%' and space character in the title results in 'is not a hex char' errors

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/FriendlyURLNormalizerImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/FriendlyURLNormalizerImpl.java
@@ -48,13 +48,9 @@ public class FriendlyURLNormalizerImpl implements FriendlyURLNormalizer {
 			return friendlyURL;
 		}
 
-		String decodedFriendlyURL = HttpUtil.decodePath(friendlyURL);
-
-		if (Validator.isNull(decodedFriendlyURL)) {
-			decodedFriendlyURL = HttpUtil.decodePath(
-				StringUtil.replace(
-					friendlyURL, CharPool.PERCENT, CharPool.POUND));
-		}
+		String decodedFriendlyURL = HttpUtil.decodePath(
+			StringUtil.replace(
+				friendlyURL, CharPool.PERCENT, CharPool.POUND));
 
 		StringBuilder sb = new StringBuilder(decodedFriendlyURL.length());
 


### PR DESCRIPTION
Hi,

Please review.

Thanks!

(The solution is removing an unnecessary call,which made the error appear in the server log.)