### PR TITLE
[TS] LPS-120520 Don't delete PortletPreferences on the target Layout if there is a corresponding PortletPreferences on the source Layout

### DIFF
--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/util/LayoutCopyHelperImpl.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/util/LayoutCopyHelperImpl.java
@@ -319,16 +319,27 @@ public class LayoutCopyHelperImpl implements LayoutCopyHelper {
 	}
 
 	private void _copyPortletPreferences(
-		Layout sourceLayout, Layout targetLayout) {
+			Layout sourceLayout, Layout targetLayout)
+		throws Exception {
 
 		List<PortletPreferences> portletPreferencesList =
 			_portletPreferencesLocalService.getPortletPreferences(
 				PortletKeys.PREFS_OWNER_ID_DEFAULT,
 				PortletKeys.PREFS_OWNER_TYPE_LAYOUT, sourceLayout.getPlid());
 
-		_portletPreferencesLocalService.deletePortletPreferences(
-			PortletKeys.PREFS_OWNER_ID_DEFAULT,
-			PortletKeys.PREFS_OWNER_TYPE_LAYOUT, targetLayout.getPlid());
+		List<PortletPreferences> targetPortletPreferencesList =
+			_portletPreferencesLocalService.getPortletPreferences(
+				PortletKeys.PREFS_OWNER_ID_DEFAULT,
+				PortletKeys.PREFS_OWNER_TYPE_LAYOUT, targetLayout.getPlid());
+
+		Stream<PortletPreferences> targetPortletPreferencesStream =
+			targetPortletPreferencesList.stream();
+
+		List<String> targetPortletIds = targetPortletPreferencesStream.map(
+			PortletPreferences::getPortletId
+		).collect(
+			Collectors.toList()
+		);
 
 		for (PortletPreferences portletPreferences : portletPreferencesList) {
 			Portlet portlet = _portletLocalService.getPortletById(
@@ -337,6 +348,8 @@ public class LayoutCopyHelperImpl implements LayoutCopyHelper {
 			if ((portlet == null) || portlet.isUndeployedPortlet()) {
 				continue;
 			}
+
+			targetPortletIds.remove(portletPreferences.getPortletId());
 
 			PortletPreferences targetPortletPreferences =
 				_portletPreferencesLocalService.fetchPortletPreferences(
@@ -361,6 +374,13 @@ public class LayoutCopyHelperImpl implements LayoutCopyHelper {
 						portletPreferences.getPortletId()),
 					portletPreferences.getPreferences());
 			}
+		}
+
+		for (String portletId : targetPortletIds) {
+			_portletPreferencesLocalService.deletePortletPreferences(
+				PortletKeys.PREFS_OWNER_ID_DEFAULT,
+				PortletKeys.PREFS_OWNER_TYPE_LAYOUT, targetLayout.getPlid(),
+				portletId);
 		}
 	}
 


### PR DESCRIPTION
Hi @dacousalr ,

`PortletPreferencesLocalService#deletePortletPreferences` has an onAfterRemove Listener `SubscriptionPortletPreferencesModelListener#onAfterRemove` which is triggered if we hard reset the target Layout's PortletPreferences to zero during Content Page Save/Publication.

Can you please review?
https://issues.liferay.com/browse/LPS-120520

Thanks,
Balázs