### PR TITLE
[TS] LPS-122314 Upgrade step for LayoutPageTemplateEntry permissions

### DIFF
--- a/modules/apps/layout/layout-page-template-service/bnd.bnd
+++ b/modules/apps/layout/layout-page-template-service/bnd.bnd
@@ -5,6 +5,6 @@ Import-Package:\
 	com.liferay.layout.page.template.util.comparator,\
 	\
 	*
-Liferay-Require-SchemaVersion: 3.4.1
+Liferay-Require-SchemaVersion: 3.4.2
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/LayoutPageTemplateServiceUpgrade.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/LayoutPageTemplateServiceUpgrade.java
@@ -22,7 +22,7 @@ import com.liferay.layout.page.template.internal.upgrade.v2_0_0.util.LayoutPageT
 import com.liferay.layout.page.template.internal.upgrade.v2_0_0.util.LayoutPageTemplateEntryTable;
 import com.liferay.layout.page.template.internal.upgrade.v2_1_0.UpgradeLayout;
 import com.liferay.layout.page.template.internal.upgrade.v3_0_1.util.LayoutPageTemplateStructureRelTable;
-import com.liferay.layout.page.template.internal.upgrade.v3_1_3.UpgradeResourcePermission;
+import com.liferay.layout.page.template.internal.upgrade.v3_1_4.UpgradeResourcePermission;
 import com.liferay.layout.page.template.internal.upgrade.v3_3_0.UpgradeLayoutPageTemplateStructureRel;
 import com.liferay.layout.page.template.internal.upgrade.v3_4_1.UpgradeFragmentEntryLinkEditableValues;
 import com.liferay.portal.kernel.service.CompanyLocalService;
@@ -111,14 +111,16 @@ public class LayoutPageTemplateServiceUpgrade
 
 		registry.register("3.1.1", "3.1.2", new DummyUpgradeStep());
 
+		registry.register("3.1.2", "3.1.3", new DummyUpgradeStep());
+
 		registry.register(
-			"3.1.2", "3.1.3",
-			new com.liferay.layout.page.template.internal.upgrade.v3_1_3.
+			"3.1.3", "3.1.4",
+			new com.liferay.layout.page.template.internal.upgrade.v3_1_4.
 				UpgradeLayoutPageTemplateEntry(),
 			new UpgradeResourcePermission());
 
 		registry.register(
-			"3.1.3", "3.2.0",
+			"3.1.4", "3.2.0",
 			new com.liferay.layout.page.template.internal.upgrade.v3_2_0.
 				UpgradeLayoutPageTemplateCollection(),
 			new com.liferay.layout.page.template.internal.upgrade.v3_2_0.

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/LayoutPageTemplateServiceUpgrade.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/LayoutPageTemplateServiceUpgrade.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.LayoutPrototypeLocalService;
 import com.liferay.portal.kernel.service.PortletPreferencesLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.upgrade.BaseUpgradeSQLServerDatetime;
 import com.liferay.portal.kernel.upgrade.DummyUpgradeStep;
 import com.liferay.portal.kernel.upgrade.UpgradeCTModel;
@@ -146,6 +147,12 @@ public class LayoutPageTemplateServiceUpgrade
 			new com.liferay.layout.page.template.internal.upgrade.v3_4_1.
 				UpgradeLayoutPageTemplateEntry(_portal),
 			new UpgradeFragmentEntryLinkEditableValues());
+
+		registry.register(
+			"3.4.1", "3.4.2",
+			new com.liferay.layout.page.template.internal.upgrade.v3_4_2.
+				UpgradeLayoutPageTemplateEntryResourcePermission(
+					_resourcePermissionLocalService));
 	}
 
 	@Reference
@@ -165,5 +172,8 @@ public class LayoutPageTemplateServiceUpgrade
 
 	@Reference
 	private PortletPreferencesLocalService _portletPreferencesLocalService;
+
+	@Reference
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
 
 }

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/LayoutPageTemplateServiceUpgrade.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/LayoutPageTemplateServiceUpgrade.java
@@ -61,8 +61,10 @@ public class LayoutPageTemplateServiceUpgrade
 			"1.1.0", "1.1.1",
 			new UpgradeLayoutPageTemplateEntry(_companyLocalService));
 
+		registry.register("1.1.1", "1.1.2", new DummyUpgradeStep());
+
 		registry.register(
-			"1.1.1", "1.2.0",
+			"1.1.2", "1.2.0",
 			new UpgradeLayoutPageTemplateStructure(
 				_fragmentEntryLinkLocalService, _layoutLocalService));
 

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v3_1_4/UpgradeLayoutPageTemplateEntry.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v3_1_4/UpgradeLayoutPageTemplateEntry.java
@@ -12,7 +12,7 @@
  * details.
  */
 
-package com.liferay.layout.page.template.internal.upgrade.v3_1_3;
+package com.liferay.layout.page.template.internal.upgrade.v3_1_4;
 
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v3_1_4/UpgradeResourcePermission.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v3_1_4/UpgradeResourcePermission.java
@@ -12,7 +12,7 @@
  * details.
  */
 
-package com.liferay.layout.page.template.internal.upgrade.v3_1_3;
+package com.liferay.layout.page.template.internal.upgrade.v3_1_4;
 
 import com.liferay.layout.admin.constants.LayoutAdminPortletKeys;
 import com.liferay.layout.page.template.admin.constants.LayoutPageTemplateAdminPortletKeys;

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v3_4_2/UpgradeLayoutPageTemplateEntryResourcePermission.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v3_4_2/UpgradeLayoutPageTemplateEntryResourcePermission.java
@@ -70,10 +70,20 @@ public class UpgradeLayoutPageTemplateEntryResourcePermission
 					resourcePermission.setPrimKey(newName);
 				}
 
-				resourcePermission.setResourcePermissionId(increment());
+				ResourcePermission existingResourcePermission =
+					_resourcePermissionLocalService.fetchResourcePermission(
+						resourcePermission.getCompanyId(),
+						resourcePermission.getName(),
+						resourcePermission.getScope(),
+						resourcePermission.getPrimKey(),
+						resourcePermission.getRoleId());
 
-				_resourcePermissionLocalService.addResourcePermission(
-					resourcePermission);
+				if (existingResourcePermission == null) {
+					resourcePermission.setResourcePermissionId(increment());
+
+					_resourcePermissionLocalService.addResourcePermission(
+						resourcePermission);
+				}
 			});
 
 		actionableDynamicQuery.performActions();

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v3_4_2/UpgradeLayoutPageTemplateEntryResourcePermission.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v3_4_2/UpgradeLayoutPageTemplateEntryResourcePermission.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.layout.page.template.internal.upgrade.v3_4_2;
+
+import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
+import com.liferay.portal.kernel.dao.orm.Property;
+import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.LayoutPrototype;
+import com.liferay.portal.kernel.model.ResourcePermission;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.LoggingTimer;
+
+import java.util.Objects;
+
+/**
+ * @author Vendel Toreki
+ */
+public class UpgradeLayoutPageTemplateEntryResourcePermission
+	extends UpgradeProcess {
+
+	public UpgradeLayoutPageTemplateEntryResourcePermission(
+		ResourcePermissionLocalService resourcePermissionLocalService) {
+
+		_resourcePermissionLocalService = resourcePermissionLocalService;
+	}
+
+	protected void copyResourcePermissions(
+			final String oldName, final String newName)
+		throws PortalException {
+
+		if (_log.isDebugEnabled()) {
+			_log.debug(
+				StringBundler.concat(
+					"Copy resource permissions from ", oldName, " to ",
+					newName));
+		}
+
+		ActionableDynamicQuery actionableDynamicQuery =
+			_resourcePermissionLocalService.getActionableDynamicQuery();
+
+		actionableDynamicQuery.setAddCriteriaMethod(
+			dynamicQuery -> {
+				Property nameProperty = PropertyFactoryUtil.forName("name");
+
+				dynamicQuery.add(nameProperty.eq(oldName));
+			});
+		actionableDynamicQuery.setPerformActionMethod(
+			(ResourcePermission resourcePermission) -> {
+				resourcePermission.setName(newName);
+
+				if (Objects.equals(resourcePermission.getPrimKey(), oldName)) {
+					resourcePermission.setPrimKey(newName);
+				}
+
+				resourcePermission.setResourcePermissionId(increment());
+
+				_resourcePermissionLocalService.addResourcePermission(
+					resourcePermission);
+			});
+
+		actionableDynamicQuery.performActions();
+	}
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		try (LoggingTimer loggingTimer = new LoggingTimer()) {
+			copyResourcePermissions(
+				LayoutPrototype.class.getName(),
+				LayoutPageTemplateEntry.class.getName());
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		UpgradeLayoutPageTemplateEntryResourcePermission.class);
+
+	private final ResourcePermissionLocalService
+		_resourcePermissionLocalService;
+
+}


### PR DESCRIPTION
Hi @dacousalr ,

As discussed on [PTR-2111](https://issues.liferay.com/browse/PTR-2111), I've added dummy upgrade steps:
* "3.1.2" to "3.1.3" for 7.2.x backport
* "1.1.1" to "1.1.2" for 7.1.x backport
* Increased the version of step 3.1.3 to 3.1.4

The https://github.com/dacousalr/liferay-portal/commit/992c63de2883ecc5e12a0d8e5e915722caff456c commit makes the upgrade step idempotent: it will not change anything if executed twice.

Please review my changes.

Thanks,
Vendel