### PR TITLE
LPS-127057 Copied Web Contents don't have FriendlyURLEntries

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -1154,6 +1154,16 @@ public class JournalArticleLocalServiceImpl
 			newTitleMap.put(locale, sb.toString());
 		}
 
+		Locale locale = getArticleDefaultLocale(oldArticle.getContent());
+
+		Map<Locale, String> friendlyURLMap = _checkFriendlyURLMap(
+			locale, new HashMap(), newTitleMap);
+
+		Map<String, String> newUrlTitleMap = _getURLTitleMap(
+			groupId, resourcePrimKey, friendlyURLMap, newTitleMap);
+
+		updateFriendlyURLs(newArticle, newUrlTitleMap, serviceContext);
+
 		_addArticleLocalizedFields(
 			newArticle.getCompanyId(), newArticle.getId(), newTitleMap,
 			oldArticle.getDescriptionMap());


### PR DESCRIPTION
Hi @dacousalr!

I have used the same logic as "add article" to create FriendlyURLEntries.

Now the duplicate web content's name is considered when generating the FriendlyUrlEntry.

Please review,

Thanks!