### PR TITLE
LPS-127734 Wrong default language in Web Content

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalEditArticleDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalEditArticleDisplayContext.java
@@ -378,7 +378,7 @@ public class JournalEditArticleDisplayContext {
 			siteDefaultLocale = LocaleUtil.getSiteDefault();
 		}
 
-		if (_article == null) {
+		if (Validator.isNull(getArticleId())) {
 			_defaultArticleLanguageId = LocaleUtil.toLanguageId(
 				siteDefaultLocale);
 		}


### PR DESCRIPTION
Hi @dacousalr ,

After your proposal in [PTR-2244](https://issues.liferay.com/browse/PTR-2244), I realized our code was already trying to do what you suggested as solution:

- New articles => Default locale is the site's default locale
- Existing articles => Default locale is taken from the article

However, the condition was not right, since __article_ is not null at that point. So instead of checking the value of __article_'s variable to know whether we are creating or editing an article, I'm checking the _articleId_, which is _null_ when creating, but it contains some value when updating.

Let me know if you have further questions about this pull request.

Thanks.

Regards.