### PR TITLE
[TECNICAL-SUPPORT] LPS-127732 Lead and small Class attribute of block-level elements are not removed when changing format

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/editor/configuration/FragmentEntryLinkRichTextEditorConfigContributor.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/editor/configuration/FragmentEntryLinkRichTextEditorConfigContributor.java
@@ -199,21 +199,23 @@ public class FragmentEntryLinkRichTextEditorConfigContributor
 
 		return JSONUtil.putAll(
 			getStyleFormatJSONObject(
-				LanguageUtil.get(resourceBundle, "small"), "span", "small", 2),
+				LanguageUtil.get(resourceBundle, "small"), "span", "small",
+				_CKEDITOR_STYLE_INLINE),
 			getStyleFormatJSONObject(
-				LanguageUtil.get(resourceBundle, "lead"), "span", "lead", 2),
+				LanguageUtil.get(resourceBundle, "lead"), "span", "lead",
+				_CKEDITOR_STYLE_INLINE),
 			getStyleFormatJSONObject(
 				LanguageUtil.format(resourceBundle, "heading-x", "1"), "h1",
-				null, 1),
+				null, _CKEDITOR_STYLE_BLOCK),
 			getStyleFormatJSONObject(
 				LanguageUtil.format(resourceBundle, "heading-x", "2"), "h2",
-				null, 1),
+				null, _CKEDITOR_STYLE_BLOCK),
 			getStyleFormatJSONObject(
 				LanguageUtil.format(resourceBundle, "heading-x", "3"), "h3",
-				null, 1),
+				null, _CKEDITOR_STYLE_BLOCK),
 			getStyleFormatJSONObject(
 				LanguageUtil.format(resourceBundle, "heading-x", "4"), "h4",
-				null, 1));
+				null, _CKEDITOR_STYLE_BLOCK));
 	}
 
 	protected JSONObject getStyleFormatsJSONObject(Locale locale) {
@@ -331,6 +333,10 @@ public class FragmentEntryLinkRichTextEditorConfigContributor
 
 		return itemSelectorCriterion;
 	}
+
+	private static final int _CKEDITOR_STYLE_BLOCK = 1;
+
+	private static final int _CKEDITOR_STYLE_INLINE = 2;
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		FragmentEntryLinkRichTextEditorConfigContributor.class);

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/editor/configuration/FragmentEntryLinkRichTextEditorConfigContributor.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/editor/configuration/FragmentEntryLinkRichTextEditorConfigContributor.java
@@ -199,9 +199,9 @@ public class FragmentEntryLinkRichTextEditorConfigContributor
 
 		return JSONUtil.putAll(
 			getStyleFormatJSONObject(
-				LanguageUtil.get(resourceBundle, "small"), "p", "small", 1),
+				LanguageUtil.get(resourceBundle, "small"), "span", "small", 2),
 			getStyleFormatJSONObject(
-				LanguageUtil.get(resourceBundle, "lead"), "p", "lead", 1),
+				LanguageUtil.get(resourceBundle, "lead"), "span", "lead", 2),
 			getStyleFormatJSONObject(
 				LanguageUtil.format(resourceBundle, "heading-x", "1"), "h1",
 				null, 1),


### PR DESCRIPTION
Hey,

[LPS-127732](https://issues.liferay.com/browse/LPS-127732)
When we are changing styles the removeformat plugin is called to make sure we are only applying the style we want on the selection:
https://github.com/liferay/alloy-editor/blob/master/src/components/buttons/button-styles-list-item.jsx#L91-L103

First we intended to fix the reported issue, by enlarging the selection to the html element as well, when using `removeformat`. It resolves the issue when we are selecting the whole paragraph, however it doesn't when we only select a word or just part of the paragraph. This proposal was reviewed, we found its limitation and concluded:
https://github.com/liferay-frontend/liferay-portal/pull/895#issuecomment-797469818

Based on our findings, I concluded the issue here is we are defining the **lead** and **small** style changes as block level changes, however in reality they are inline level styles and they can also be applied trough the usage of html elements -> `<small>` and `<big>`
This is what is used in ckeditor if you check
https://ckeditor.com/docs/ckeditor4/latest/examples/removeformat.html

If we check https://ckeditor.com/docs/ckeditor4/latest/examples/removeformat.html
we can see ckeditor defined `small` and `big` as inline styles and they also end up using their html tag equivalent -> `<big> <small>`
I modified the configuration to apply these styles to our selection with a `<span>` html tag and made them inline level styles, as they should be.
Because of this change, the block level and inline level styles are separated and does not have an effect on each other, unless the whole paragraph is selected. This behaviour is the same as in ckeditor and prevents confusion about the intended behaviour.

Please review my change.