### PR TITLE
LPS-127057 Copied Web Contents have incorrect FriendlyURLEntries

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -1072,9 +1072,6 @@ public class JournalArticleLocalServiceImpl
 		newArticle.setTreePath(oldArticle.getTreePath());
 		newArticle.setArticleId(newArticleId);
 		newArticle.setVersion(JournalArticleConstants.VERSION_DEFAULT);
-		newArticle.setUrlTitle(
-			getUniqueUrlTitle(
-				id, groupId, newArticleId, oldArticle.getTitleCurrentValue()));
 
 		try {
 			copyArticleImages(oldArticle, newArticle);
@@ -1122,8 +1119,6 @@ public class JournalArticleLocalServiceImpl
 		ExpandoBridgeUtil.copyExpandoBridgeAttributes(
 			oldArticle.getExpandoBridge(), newArticle.getExpandoBridge());
 
-		newArticle = journalArticlePersistence.update(newArticle);
-
 		// Article localization
 
 		int uniqueUrlTitleCount = _getUniqueUrlTitleCount(
@@ -1131,6 +1126,8 @@ public class JournalArticleLocalServiceImpl
 			JournalUtil.getUrlTitle(id, oldArticle.getUrlTitle()));
 
 		Map<Locale, String> newTitleMap = oldArticle.getTitleMap();
+
+		Map<Locale, String> newUniqueURLTitleMap = new HashMap<>();
 
 		for (Map.Entry<Locale, String> entry : newTitleMap.entrySet()) {
 			Locale locale = entry.getKey();
@@ -1144,7 +1141,32 @@ public class JournalArticleLocalServiceImpl
 			sb.append(uniqueUrlTitleCount);
 
 			newTitleMap.put(locale, sb.toString());
+
+			newUniqueURLTitleMap.put(
+				locale,
+				getUniqueUrlTitle(id, groupId, newArticleId, sb.toString()));
 		}
+
+		Locale locale = getArticleDefaultLocale(oldArticle.getContent());
+
+		String newURLTitle = newUniqueURLTitleMap.get(locale);
+
+		while (fetchArticleByUrlTitle(groupId, newURLTitle) != null) {
+			newURLTitle = getUniqueUrlTitle(
+				id, groupId, newArticleId, newURLTitle);
+		}
+
+		newArticle.setUrlTitle(newURLTitle);
+
+		newArticle = journalArticlePersistence.update(newArticle);
+
+		Map<Locale, String> friendlyURLMap = _checkFriendlyURLMap(
+			locale, new HashMap(), newTitleMap);
+
+		Map<String, String> newUrlTitleMap = _getURLTitleMap(
+			groupId, resourcePrimKey, friendlyURLMap, newUniqueURLTitleMap);
+
+		updateFriendlyURLs(newArticle, newUrlTitleMap, serviceContext);
 
 		_addArticleLocalizedFields(
 			newArticle.getCompanyId(), newArticle.getId(), newTitleMap,


### PR DESCRIPTION
Hi @dacousalr !

I have tried to implement the changes you requested:
"first set article.setUrlTitle(urlTitle), second call journalArticlePersistence.update, third, create the corresponding friendlyURLLocalizationEntry entries "

Is this the solution you asked? 

Please review.

Thanks!