### PR TITLE
LPS-128928 AssetCategory association may be lost when content editor has limited permissions

### DIFF
--- a/modules/apps/asset/asset-taglib/bnd.bnd
+++ b/modules/apps/asset/asset-taglib/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Asset Taglib
 Bundle-SymbolicName: com.liferay.asset.taglib
-Bundle-Version: 6.0.2
+Bundle-Version: 6.1.0
 Export-Package: com.liferay.asset.taglib.servlet.taglib
 Liferay-JS-Config: /META-INF/resources/config.js
 Provide-Capability:\

--- a/modules/apps/asset/asset-taglib/package.json
+++ b/modules/apps/asset/asset-taglib/package.json
@@ -17,5 +17,5 @@
 		"checkFormat": "liferay-npm-scripts check",
 		"format": "liferay-npm-scripts fix"
 	},
-	"version": "6.0.2"
+	"version": "6.1.0"
 }

--- a/modules/apps/asset/asset-taglib/src/main/java/com/liferay/asset/taglib/servlet/taglib/AssetCategoriesSelectorTag.java
+++ b/modules/apps/asset/asset-taglib/src/main/java/com/liferay/asset/taglib/servlet/taglib/AssetCategoriesSelectorTag.java
@@ -19,6 +19,7 @@ import com.liferay.asset.kernel.model.AssetCategory;
 import com.liferay.asset.kernel.model.AssetCategoryConstants;
 import com.liferay.asset.kernel.model.AssetVocabulary;
 import com.liferay.asset.kernel.model.AssetVocabularyConstants;
+import com.liferay.asset.kernel.service.AssetCategoryLocalServiceUtil;
 import com.liferay.asset.kernel.service.AssetCategoryServiceUtil;
 import com.liferay.asset.kernel.service.AssetVocabularyServiceUtil;
 import com.liferay.asset.taglib.internal.servlet.ServletContextUtil;
@@ -26,6 +27,7 @@ import com.liferay.asset.taglib.internal.util.AssetCategoryUtil;
 import com.liferay.asset.taglib.internal.util.AssetVocabularyUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.petra.string.StringUtil;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.module.configuration.ConfigurationProviderUtil;
@@ -47,6 +49,8 @@ import com.liferay.taglib.util.IncludeTag;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.portlet.PortletRequest;
 import javax.portlet.PortletResponse;
@@ -315,6 +319,25 @@ public class AssetCategoriesSelectorTag extends IncludeTag {
 		return null;
 	}
 
+	protected Long[] getRestrictedCategoryIds() throws PortalException {
+		List<AssetCategory> categories =
+			AssetCategoryLocalServiceUtil.getCategories(_className, _classPK);
+		List<AssetCategory> filteredCategories =
+			AssetCategoryServiceUtil.getCategories(_className, _classPK);
+
+		Stream<AssetCategory> categoriesStream = categories.stream();
+
+		List<Long> restrictedCategoryIds = categoriesStream.filter(
+			n -> !filteredCategories.contains(n)
+		).map(
+			n -> n.getCategoryId()
+		).collect(
+			Collectors.toList()
+		);
+
+		return restrictedCategoryIds.toArray(new Long[0]);
+	}
+
 	protected List<Map<String, Object>> getVocabularies() throws Exception {
 		ThemeDisplay themeDisplay = (ThemeDisplay)request.getAttribute(
 			WebKeys.THEME_DISPLAY);
@@ -425,6 +448,8 @@ public class AssetCategoriesSelectorTag extends IncludeTag {
 					}
 				).put(
 					"portletURL", getPortletURL().toString()
+				).put(
+					"restrictedCategoryIds", getRestrictedCategoryIds()
 				).put(
 					"vocabularies", getVocabularies()
 				).build());

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_selector/AssetCategoriesSelectorTag.es.js
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_selector/AssetCategoriesSelectorTag.es.js
@@ -62,6 +62,8 @@ export default function (props) {
 			vocabulary.visibilityType ===
 			ASSET_VOCABULARY_VISIBILITY_TYPES.internal
 	);
+	const inputName = props.inputName;
+	const restrictedCategoryIds = props.restrictedCategoryIds;
 
 	return (
 		<>
@@ -118,6 +120,21 @@ export default function (props) {
 						/>
 					</>
 				)}
+
+			{restrictedCategoryIds && restrictedCategoryIds.length > 0 && (
+				<>
+					{restrictedCategoryIds.map((categoryId) => {
+						return (
+							<input
+								key={categoryId}
+								name={inputName}
+								type="hidden"
+								value={categoryId}
+							/>
+						);
+					})}
+				</>
+			)}
 		</>
 	);
 }

--- a/modules/apps/asset/asset-taglib/src/main/resources/com/liferay/asset/taglib/servlet/taglib/packageinfo
+++ b/modules/apps/asset/asset-taglib/src/main/resources/com/liferay/asset/taglib/servlet/taglib/packageinfo
@@ -1,1 +1,1 @@
-version 2.2.0
+version 2.3.0


### PR DESCRIPTION
[LPS-128928](https://issues.liferay.com/browse/LPS-128928)
Hi Daniel,

I hope you can review my changes.

In short, the issue is that AssetCategoriesSelectorTag filters the categories to display by permission. This means that if an editor doesn't have permission to see any of assigned categories, those associations are lost when the editor updates the content.

My changes ensures to send back all the assigned categoryIds to the server, even if the editor doesn't have access to those categories.

Thank you,
Istvan