### PR TITLE
LPS-132408 View in context link is missing in My Workflow Tasks review of web content with a display page template

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/asset/model/JournalArticleAssetRenderer.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/asset/model/JournalArticleAssetRenderer.java
@@ -405,7 +405,9 @@ public class JournalArticleAssetRenderer
 
 		Group group = themeDisplay.getScopeGroup();
 
-		if (!_isShowDisplayPage(group.getGroupId(), _article)) {
+		if (!_isShowDisplayPage(group.getGroupId(), _article) &&
+			!_isShowDisplayPage(_article.getGroupId(), _article)) {
+
 			String hitLayoutURL = getHitLayoutURL(
 				layout.isPrivateLayout(), noSuchEntryRedirect, themeDisplay);
 


### PR DESCRIPTION
Hi @dacousalr ,
Could you please review this pull request?
https://issues.liferay.com/browse/PTR-2432
According to your suggestions I have involved the article groupId into the condition. I hope I understood your opinion well.
I know It's seems like code duplication, but the other option is to extend the _isShowDisplayPage method and every other methods which are used in this method, I think It would be an overkill. With this change the workflow link works well for me. I see there are other LPPs pending on this LPS/PTR which I have not tested bc of lack of time. I hope you know more this module and you are able to decide the solution will work as expected in every possible case.
Thank you and best regards,
Marci