### PR TITLE
[TECHNICAL SUPPORT] LPS-133735 Prevent the Page Tree and the Site Builder's Pages menu (displaying the Miller columns) from being open at the same time

### DIFF
--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/portlet/init.jsp
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/portlet/init.jsp
@@ -31,7 +31,6 @@ taglib uri="http://liferay.com/tld/util" prefix="liferay-util" %>
 
 <%@ page import="com.liferay.application.list.PanelCategory" %><%@
 page import="com.liferay.petra.string.StringPool" %><%@
-page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
 page import="com.liferay.portal.kernel.model.Group" %><%@
 page import="com.liferay.portal.kernel.module.configuration.ConfigurationProviderUtil" %><%@
 page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@

--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/portlet/pages_tree.jsp
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/portlet/pages_tree.jsp
@@ -167,12 +167,6 @@ LayoutsTreeDisplayContext layoutsTreeDisplayContext = new LayoutsTreeDisplayCont
 		selPlid="<%= layoutsTreeDisplayContext.getSelPlid() %>"
 		treeId="pagesTree"
 	/>
-
-	<c:if test="<%= layoutsTreeDisplayContext.hasAdministrationPortletPermission() %>">
-		<div class="pages-administration-link">
-			<aui:a cssClass="ml-2" href="<%= layoutsTreeDisplayContext.getAdministrationPortletURL() %>"><%= LanguageUtil.get(request, "go-to-pages-administration") %></aui:a>
-		</div>
-	</c:if>
 </div>
 
 <liferay-frontend:component

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_body.jsp
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_body.jsp
@@ -134,6 +134,11 @@ Group group = siteAdministrationPanelCategoryDisplayContext.getGroup();
 			'<portlet:namespace />pagesTreeSidenavToggleId'
 		);
 
+		if (Liferay.currentURL.includes(
+			"com_liferay_layout_admin_web_portlet_GroupPagesPortlet")) {
+			pagesTreeToggle.classList.add('disabled');
+		}
+
 		pagesTreeToggle.addEventListener('click', (event) => {
 			Liferay.Portlet.destroy('#p_p_id<portlet:namespace />', true);
 


### PR DESCRIPTION
Hey,
[LPS-133735](https://issues.liferay.com/browse/LPS-133735),
[PTR-2458](https://issues.liferay.com/browse/PTR-2458),

Based on the above linked PTR I created this solution, please review it.

Thank you,