### PR TITLE
LPS-135087

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/LayoutReferencesExportImportContentProcessor.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/LayoutReferencesExportImportContentProcessor.java
@@ -393,6 +393,31 @@ public class LayoutReferencesExportImportContentProcessor
 
 						layoutSet = group.getPrivateLayoutSet();
 					}
+					else if (urlSBString.contains(
+								_DATA_HANDLER_COMPANY_SECURE_URL) ||
+							 urlSBString.contains(_DATA_HANDLER_COMPANY_URL)) {
+
+						if (StringUtil.equals(
+								group.getGroupKey(),
+								PropsValues.VIRTUAL_HOSTS_DEFAULT_SITE_NAME)) {
+
+							layoutSet = group.getPublicLayoutSet();
+						}
+					}
+					else {
+						LayoutSet publicLayoutSet = group.getPublicLayoutSet();
+
+						TreeMap<String, String> publicVirtualHostnames =
+							publicLayoutSet.getVirtualHostnames();
+
+						if (!publicVirtualHostnames.isEmpty() ||
+							StringUtil.equals(
+								group.getGroupKey(),
+								PropsValues.VIRTUAL_HOSTS_DEFAULT_SITE_NAME)) {
+
+							layoutSet = group.getPublicLayoutSet();
+						}
+					}
 
 					if (layoutSet == null) {
 						continue;

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/LayoutReferencesExportImportContentProcessor.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/LayoutReferencesExportImportContentProcessor.java
@@ -694,6 +694,13 @@ public class LayoutReferencesExportImportContentProcessor
 			if (content.charAt(groupUuidPos) == CharPool.AT) {
 				endIndex = content.indexOf(StringPool.AT, groupUuidPos + 1);
 			}
+			else {
+				content = StringUtil.replaceFirst(
+					content, _DATA_HANDLER_GROUP_FRIENDLY_URL,
+					group.getFriendlyURL(), groupFriendlyUrlPos);
+
+				continue;
+			}
 
 			if (endIndex < (groupUuidPos + 1)) {
 				content = StringUtil.replaceFirst(

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/LayoutReferencesExportImportContentProcessor.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/LayoutReferencesExportImportContentProcessor.java
@@ -953,6 +953,31 @@ public class LayoutReferencesExportImportContentProcessor
 
 					layoutSet = group.getPrivateLayoutSet();
 				}
+				else if (urlSBString.contains(
+							_DATA_HANDLER_COMPANY_SECURE_URL) ||
+						 urlSBString.contains(_DATA_HANDLER_COMPANY_URL)) {
+
+					if (StringUtil.equals(
+							group.getGroupKey(),
+							PropsValues.VIRTUAL_HOSTS_DEFAULT_SITE_NAME)) {
+
+						layoutSet = group.getPublicLayoutSet();
+					}
+				}
+				else {
+					LayoutSet publicLayoutSet = group.getPublicLayoutSet();
+
+					TreeMap<String, String> publicVirtualHostnames =
+						publicLayoutSet.getVirtualHostnames();
+
+					if (!publicVirtualHostnames.isEmpty() ||
+						StringUtil.equals(
+							group.getGroupKey(),
+							PropsValues.VIRTUAL_HOSTS_DEFAULT_SITE_NAME)) {
+
+						layoutSet = group.getPublicLayoutSet();
+					}
+				}
 
 				if (layoutSet == null) {
 					continue;


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-135087

Hi @dacousalr,

This pull request contains changes pertaining to what we discussed on [PTR-2516](https://issues.liferay.com/browse/PTR-2516).

I wanted to keep it simple for this first pull request. My thinking is we can fix things incrementally.

I noticed we already had logic in place to export/import the same-site layout in the case that the URL is of the form [PUBLIC_PAGES_VIRTUAL_HOST][LAYOUT_FRIENDLY_URL] or [PRIVATE_PAGES_VIRTUAL_HOST][LAYOUT_FRIENDLY_URL].

So, for the first two commits, I simply added cases for URLs of the form [COMPANY_VIRTUAL_HOST][LAYOUT_FRIENDLY_URL] and just [LAYOUT_FRIENDLY_URL] (the relative URL).

For the third commit, I fixed a bug I discovered in the aforementioned existing logic to import URLs of these forms.

Currently, the existing logic does not "try" to keep the URL in the same form it was in. When it exports it, it always appends the servlet mapping and Group friendly URL. I think we can send a follow-up pull request to do this, but I think it is lower-priority since the first priority should just be to just import a link that isn't broken. I think it may also be substantially more complex to fix.

Also, this doesn't handle the case where the absolute URL points to a different site's virtual host. I think we can send a follow-up pull for that as well. I think this may also be complicated to fix though because we need to hash out what the expected behavior should be to properly identify the Group that the URL is pointing to on the import side.

I wanted to go ahead and send you this first pull request now, since it solves the customer's issue, and it is a high-priority issue that has been open for a long time. Let me know if you disagree or you want me to add the other changes we discussed into this pull request.