### PR TITLE
LPS-136108 More accurate

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/LayoutReferencesExportImportContentProcessor.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/LayoutReferencesExportImportContentProcessor.java
@@ -398,12 +398,11 @@ public class LayoutReferencesExportImportContentProcessor
 						layoutSet = group.getPrivateLayoutSet();
 					}
 					else if (urlSBString.contains(
-								_DATA_HANDLER_COMPANY_SECURE_URL) ||
-							 urlSBString.contains(_DATA_HANDLER_COMPANY_URL)) {
+								_DATA_HANDLER_COMPANY_SECURE_DEFAULT_GROUP_URL) ||
+							 urlSBString.contains(
+								 _DATA_HANDLER_COMPANY_DEFAULT_GROUP_URL)) {
 
-						if (_isDefaultGroup(group)) {
-							layoutSet = group.getPublicLayoutSet();
-						}
+						layoutSet = group.getPublicLayoutSet();
 					}
 					else {
 						LayoutSet publicLayoutSet = group.getPublicLayoutSet();
@@ -1016,12 +1015,11 @@ public class LayoutReferencesExportImportContentProcessor
 					layoutSet = group.getPrivateLayoutSet();
 				}
 				else if (urlSBString.contains(
-							_DATA_HANDLER_COMPANY_SECURE_URL) ||
-						 urlSBString.contains(_DATA_HANDLER_COMPANY_URL)) {
+							_DATA_HANDLER_COMPANY_SECURE_DEFAULT_GROUP_URL) ||
+						 urlSBString.contains(
+							 _DATA_HANDLER_COMPANY_DEFAULT_GROUP_URL)) {
 
-					if (_isDefaultGroup(group)) {
-						layoutSet = group.getPublicLayoutSet();
-					}
+					layoutSet = group.getPublicLayoutSet();
 				}
 				else {
 					LayoutSet publicLayoutSet = group.getPublicLayoutSet();

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/LayoutReferencesExportImportContentProcessor.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/LayoutReferencesExportImportContentProcessor.java
@@ -136,11 +136,8 @@ public class LayoutReferencesExportImportContentProcessor
 		String portalURL = StringPool.BLANK;
 
 		if (!publicLayoutSetVirtualHostnames.isEmpty()) {
-			portalURL = _getPortalURL(
-				url,
-				_portal.getPortalURL(
-					publicLayoutSetVirtualHostnames.firstKey(), serverPort,
-					secure));
+			portalURL = _portal.getPortalURL(
+				publicLayoutSetVirtualHostnames.firstKey(), serverPort, secure);
 
 			if (url.startsWith(portalURL)) {
 				if (secure) {
@@ -160,11 +157,9 @@ public class LayoutReferencesExportImportContentProcessor
 			privateLayoutSet.getVirtualHostnames();
 
 		if (!privateLayoutSetVirtualHostnames.isEmpty()) {
-			portalURL = _getPortalURL(
-				url,
-				_portal.getPortalURL(
-					privateLayoutSetVirtualHostnames.firstKey(), serverPort,
-					secure));
+			portalURL = _portal.getPortalURL(
+				privateLayoutSetVirtualHostnames.firstKey(), serverPort,
+				secure);
 
 			if (url.startsWith(portalURL)) {
 				if (secure) {

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/LayoutReferencesExportImportContentProcessor.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/LayoutReferencesExportImportContentProcessor.java
@@ -184,7 +184,19 @@ public class LayoutReferencesExportImportContentProcessor
 					companyVirtualHostname, serverPort, secure));
 
 			if (url.startsWith(portalURL)) {
-				if (secure) {
+				if (StringUtil.equals(
+						group.getGroupKey(),
+						PropsValues.VIRTUAL_HOSTS_DEFAULT_SITE_NAME)) {
+
+					if (secure) {
+						urlSB.append(
+							_DATA_HANDLER_COMPANY_SECURE_DEFAULT_GROUP_URL);
+					}
+					else {
+						urlSB.append(_DATA_HANDLER_COMPANY_DEFAULT_GROUP_URL);
+					}
+				}
+				else if (secure) {
 					urlSB.append(_DATA_HANDLER_COMPANY_SECURE_URL);
 				}
 				else {
@@ -1165,6 +1177,12 @@ public class LayoutReferencesExportImportContentProcessor
 
 		return content;
 	}
+
+	private static final String _DATA_HANDLER_COMPANY_DEFAULT_GROUP_URL =
+		"@data_handler_company_default_group_url@";
+
+	private static final String _DATA_HANDLER_COMPANY_SECURE_DEFAULT_GROUP_URL =
+		"@data_handler_company_secure_default_group_url@";
 
 	private static final String _DATA_HANDLER_COMPANY_SECURE_URL =
 		"@data_handler_company_secure_url@";

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/LayoutReferencesExportImportContentProcessor.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/LayoutReferencesExportImportContentProcessor.java
@@ -593,6 +593,7 @@ public class LayoutReferencesExportImportContentProcessor
 			PortletDataContext portletDataContext, String content)
 		throws Exception {
 
+		String companyDefaultGroupPortalURL = StringPool.BLANK;
 		String companyPortalURL = StringPool.BLANK;
 		String privateLayoutSetPortalURL = StringPool.BLANK;
 		String publicLayoutSetPortalURL = StringPool.BLANK;
@@ -634,10 +635,21 @@ public class LayoutReferencesExportImportContentProcessor
 			else {
 				publicLayoutSetPortalURL = companyPortalURL;
 			}
+
+			if (StringUtil.equals(
+					group.getGroupKey(),
+					PropsValues.VIRTUAL_HOSTS_DEFAULT_SITE_NAME)) {
+
+				companyDefaultGroupPortalURL = companyPortalURL;
+			}
+			else {
+				companyDefaultGroupPortalURL = publicLayoutSetPortalURL;
+			}
 		}
 
 		int secureSecurePort = _portal.getPortalServerPort(true);
 
+		String companySecureDefaultGroupPortalURL = StringPool.BLANK;
 		String companySecurePortalURL = StringPool.BLANK;
 		String privateLayoutSetSecurePortalURL = StringPool.BLANK;
 		String publicLayoutSetSecurePortalURL = StringPool.BLANK;
@@ -663,6 +675,17 @@ public class LayoutReferencesExportImportContentProcessor
 				publicLayoutSetSecurePortalURL = _portal.getPortalURL(
 					publicVirtualHostnames.firstKey(), secureSecurePort, true);
 			}
+
+			if (StringUtil.equals(
+					group.getGroupKey(),
+					PropsValues.VIRTUAL_HOSTS_DEFAULT_SITE_NAME)) {
+
+				companySecureDefaultGroupPortalURL = companySecurePortalURL;
+			}
+			else {
+				companySecureDefaultGroupPortalURL =
+					publicLayoutSetSecurePortalURL;
+			}
 		}
 
 		StringBundler sb = new StringBundler(3);
@@ -671,6 +694,12 @@ public class LayoutReferencesExportImportContentProcessor
 		sb.append(GroupConstants.CONTROL_PANEL_FRIENDLY_URL);
 		sb.append(PropsValues.CONTROL_PANEL_LAYOUT_FRIENDLY_URL);
 
+		content = StringUtil.replace(
+			content, _DATA_HANDLER_COMPANY_DEFAULT_GROUP_URL,
+			companyDefaultGroupPortalURL);
+		content = StringUtil.replace(
+			content, _DATA_HANDLER_COMPANY_SECURE_DEFAULT_GROUP_URL,
+			companySecureDefaultGroupPortalURL);
 		content = StringUtil.replace(
 			content, _DATA_HANDLER_COMPANY_SECURE_URL, companySecurePortalURL);
 		content = StringUtil.replace(

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/LayoutReferencesExportImportContentProcessor.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/LayoutReferencesExportImportContentProcessor.java
@@ -184,10 +184,7 @@ public class LayoutReferencesExportImportContentProcessor
 					companyVirtualHostname, serverPort, secure));
 
 			if (url.startsWith(portalURL)) {
-				if (StringUtil.equals(
-						group.getGroupKey(),
-						PropsValues.VIRTUAL_HOSTS_DEFAULT_SITE_NAME)) {
-
+				if (_isDefaultGroup(group)) {
 					if (secure) {
 						urlSB.append(
 							_DATA_HANDLER_COMPANY_SECURE_DEFAULT_GROUP_URL);
@@ -404,10 +401,7 @@ public class LayoutReferencesExportImportContentProcessor
 								_DATA_HANDLER_COMPANY_SECURE_URL) ||
 							 urlSBString.contains(_DATA_HANDLER_COMPANY_URL)) {
 
-						if (StringUtil.equals(
-								group.getGroupKey(),
-								PropsValues.VIRTUAL_HOSTS_DEFAULT_SITE_NAME)) {
-
+						if (_isDefaultGroup(group)) {
 							layoutSet = group.getPublicLayoutSet();
 						}
 					}
@@ -418,9 +412,7 @@ public class LayoutReferencesExportImportContentProcessor
 							publicLayoutSet.getVirtualHostnames();
 
 						if (!publicVirtualHostnames.isEmpty() ||
-							StringUtil.equals(
-								group.getGroupKey(),
-								PropsValues.VIRTUAL_HOSTS_DEFAULT_SITE_NAME)) {
+							_isDefaultGroup(group)) {
 
 							layoutSet = group.getPublicLayoutSet();
 						}
@@ -636,10 +628,7 @@ public class LayoutReferencesExportImportContentProcessor
 				publicLayoutSetPortalURL = companyPortalURL;
 			}
 
-			if (StringUtil.equals(
-					group.getGroupKey(),
-					PropsValues.VIRTUAL_HOSTS_DEFAULT_SITE_NAME)) {
-
+			if (_isDefaultGroup(group)) {
 				companyDefaultGroupPortalURL = companyPortalURL;
 			}
 			else {
@@ -676,10 +665,7 @@ public class LayoutReferencesExportImportContentProcessor
 					publicVirtualHostnames.firstKey(), secureSecurePort, true);
 			}
 
-			if (StringUtil.equals(
-					group.getGroupKey(),
-					PropsValues.VIRTUAL_HOSTS_DEFAULT_SITE_NAME)) {
-
+			if (_isDefaultGroup(group)) {
 				companySecureDefaultGroupPortalURL = companySecurePortalURL;
 			}
 			else {
@@ -731,11 +717,7 @@ public class LayoutReferencesExportImportContentProcessor
 		TreeMap<String, String> publicVirtualHostnames =
 			publicLayoutSet.getVirtualHostnames();
 
-		if (publicVirtualHostnames.isEmpty() &&
-			!StringUtil.equals(
-				PropsValues.VIRTUAL_HOSTS_DEFAULT_SITE_NAME,
-				group.getGroupKey())) {
-
+		if (publicVirtualHostnames.isEmpty() && !_isDefaultGroup(group)) {
 			virtualHostPublicLayoutFriendlyURLReplacement =
 				PropsValues.LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING +
 					group.getFriendlyURL();
@@ -1037,10 +1019,7 @@ public class LayoutReferencesExportImportContentProcessor
 							_DATA_HANDLER_COMPANY_SECURE_URL) ||
 						 urlSBString.contains(_DATA_HANDLER_COMPANY_URL)) {
 
-					if (StringUtil.equals(
-							group.getGroupKey(),
-							PropsValues.VIRTUAL_HOSTS_DEFAULT_SITE_NAME)) {
-
+					if (_isDefaultGroup(group)) {
 						layoutSet = group.getPublicLayoutSet();
 					}
 				}
@@ -1051,9 +1030,7 @@ public class LayoutReferencesExportImportContentProcessor
 						publicLayoutSet.getVirtualHostnames();
 
 					if (!publicVirtualHostnames.isEmpty() ||
-						StringUtil.equals(
-							group.getGroupKey(),
-							PropsValues.VIRTUAL_HOSTS_DEFAULT_SITE_NAME)) {
+						_isDefaultGroup(group)) {
 
 						layoutSet = group.getPublicLayoutSet();
 					}
@@ -1174,6 +1151,11 @@ public class LayoutReferencesExportImportContentProcessor
 		}
 
 		return portalURL;
+	}
+
+	private boolean _isDefaultGroup(Group group) {
+		return StringUtil.equals(
+			group.getGroupKey(), PropsValues.VIRTUAL_HOSTS_DEFAULT_SITE_NAME);
 	}
 
 	private boolean _isVirtualHostDefined(StringBundler urlSB) {

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/LayoutReferencesExportImportContentProcessor.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/LayoutReferencesExportImportContentProcessor.java
@@ -430,20 +430,13 @@ public class LayoutReferencesExportImportContentProcessor
 					}
 
 					if (privateLayout) {
-						if (group.isUser()) {
-							urlSB.append(
-								_DATA_HANDLER_PRIVATE_USER_SERVLET_MAPPING);
-						}
-						else {
-							urlSB.append(
-								_DATA_HANDLER_PRIVATE_GROUP_SERVLET_MAPPING);
-						}
+						urlSB.append(
+							_DATA_HANDLER_VIRTUAL_HOST_PRIVATE_LAYOUT_FRIENDLY_URL);
 					}
 					else {
-						urlSB.append(_DATA_HANDLER_PUBLIC_SERVLET_MAPPING);
+						urlSB.append(
+							_DATA_HANDLER_VIRTUAL_HOST_PUBLIC_LAYOUT_FRIENDLY_URL);
 					}
-
-					urlSB.append(_DATA_HANDLER_GROUP_FRIENDLY_URL);
 
 					continue;
 				}
@@ -1166,6 +1159,14 @@ public class LayoutReferencesExportImportContentProcessor
 
 	private static final String _DATA_HANDLER_SITE_ADMIN_URL =
 		"@data_handler_site_admin_url@";
+
+	private static final String
+		_DATA_HANDLER_VIRTUAL_HOST_PRIVATE_LAYOUT_FRIENDLY_URL =
+			"@data_handler_virtual_host_private_layout_friendly_url@";
+
+	private static final String
+		_DATA_HANDLER_VIRTUAL_HOST_PUBLIC_LAYOUT_FRIENDLY_URL =
+			"@data_handler_virtual_host_public_layout_friendly_url@";
 
 	private static final char[] _LAYOUT_REFERENCE_STOP_CHARS = {
 		CharPool.APOSTROPHE, CharPool.CLOSE_BRACKET, CharPool.CLOSE_CURLY_BRACE,

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/LayoutReferencesExportImportContentProcessor.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/LayoutReferencesExportImportContentProcessor.java
@@ -664,6 +664,42 @@ public class LayoutReferencesExportImportContentProcessor
 		content = StringUtil.replace(
 			content, _DATA_HANDLER_COMPANY_URL, companyPortalURL);
 
+		String virtualHostPrivateLayoutFriendlyURLReplacement =
+			StringPool.BLANK;
+		String virtualHostPublicLayoutFriendlyURLReplacement = StringPool.BLANK;
+
+		TreeMap<String, String> privateVirtualHostnames =
+			privateLayoutSet.getVirtualHostnames();
+
+		if (privateVirtualHostnames.isEmpty()) {
+			if (group.isUser()) {
+				virtualHostPrivateLayoutFriendlyURLReplacement =
+					PropsValues.
+						LAYOUT_FRIENDLY_URL_PRIVATE_USER_SERVLET_MAPPING;
+			}
+			else {
+				virtualHostPrivateLayoutFriendlyURLReplacement =
+					PropsValues.
+						LAYOUT_FRIENDLY_URL_PRIVATE_GROUP_SERVLET_MAPPING;
+			}
+
+			virtualHostPrivateLayoutFriendlyURLReplacement +=
+				group.getFriendlyURL();
+		}
+
+		TreeMap<String, String> publicVirtualHostnames =
+			publicLayoutSet.getVirtualHostnames();
+
+		if (publicVirtualHostnames.isEmpty() &&
+			!StringUtil.equals(
+				PropsValues.VIRTUAL_HOSTS_DEFAULT_SITE_NAME,
+				group.getGroupKey())) {
+
+			virtualHostPublicLayoutFriendlyURLReplacement =
+				PropsValues.LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING +
+					group.getFriendlyURL();
+		}
+
 		// Group friendly URLs
 
 		while (true) {
@@ -761,6 +797,12 @@ public class LayoutReferencesExportImportContentProcessor
 			PropsValues.LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING);
 		content = StringUtil.replace(
 			content, _DATA_HANDLER_SITE_ADMIN_URL, sb.toString());
+		content = StringUtil.replace(
+			content, _DATA_HANDLER_VIRTUAL_HOST_PRIVATE_LAYOUT_FRIENDLY_URL,
+			virtualHostPrivateLayoutFriendlyURLReplacement);
+		content = StringUtil.replace(
+			content, _DATA_HANDLER_VIRTUAL_HOST_PUBLIC_LAYOUT_FRIENDLY_URL,
+			virtualHostPublicLayoutFriendlyURLReplacement);
 
 		return content;
 	}


### PR DESCRIPTION
@mbowerman originally wrote:

> Hi Daniel,
> 
> This pull request is to keep the URL formatting consistent during import/export whenever possible (specifically, in cases where the exported URL lacks the servlet mapping and group friendly URL), as we discussed on PTR-2516.
> 
> I'm also including LPS-136320 with this fix since the fix won't really work properly without it. Note that I retested the issue described in LPS-106335 after making this commit, and it still behaves correctly.
> 
> I tested this pretty thoroughly and am pretty confident that it at least shouldn't cause any regressions. Any time we can keep the URL in the "/test-page" format, we do; otherwise, we append the servlet mapping and group friendly URL to it (e.g. "/web/guest/test-page").
> 
> One of the more noteworthy changes in this pull request, which could have implications outside of this immediate fix, is to modify the behavior when a URL is exported from the default site that uses the company host. Because the company host functions identically to a Public Pages virtual host for the default site, I modified the behavior such that the URL is modified to use the Public Pages virtual host on the import site (if one exists). This change is handled by commits 9b4d73e and bd30f9e.
> 
> Please feel free to let me know if you have any questions.
> 
> issues.liferay.com/browse/LPS-136108