### PR TITLE
LPS-137328 We should only care when the string is actually null. An e…

### DIFF
--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
@@ -666,7 +666,7 @@ public class FriendlyURLEntryLocalServiceImpl
 			String normalizedUrlTitle =
 				FriendlyURLNormalizerUtil.normalizeWithEncoding(oldURLTitle);
 
-			if (Validator.isNull(normalizedUrlTitle)) {
+			if (normalizedUrlTitle == null) {
 				continue;
 			}
 


### PR DESCRIPTION
…mpty string implies user wants to delete the friendlyURL.

https://issues.liferay.com/browse/LPS-137328

Hey @dacousalr ,

The root cause of the behavior is in FriendlyURLEntryLocalServiceImpl which is why I am sending this PR to you even though the sub issues are related to Commerce.

I'd like this fix merged as soon as possible so I can work on the COMMERCE ticket for the sub issues.

Sincerely,
Brian Kim