### PR TITLE
LPS-136108 Integration Tests

### DIFF
--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/content/processor/test/LayoutReferencesExportImportContentProcessorTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/content/processor/test/LayoutReferencesExportImportContentProcessorTest.java
@@ -123,6 +123,55 @@ public class LayoutReferencesExportImportContentProcessorTest {
 	}
 
 	@Test
+	public void testExportDefaultGroupCompanyHostImportNoVirtualHost()
+		throws Exception {
+
+		Group exportGroup = GroupTestUtil.addGroup();
+		Group importGroup = GroupTestUtil.addGroup();
+
+		Layout exportLayout = LayoutTestUtil.addLayout(exportGroup);
+
+		String urlToExport =
+			_getCompanyHostPortalURL(exportGroup) +
+				exportLayout.getFriendlyURL();
+
+		String actualImportedURL = _exportAndImportLayoutURL(
+			urlToExport, exportGroup, importGroup, true, false);
+
+		Assert.assertEquals(
+			_getCompanyHostPortalURL(importGroup) +
+				PropsValues.LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING +
+					importGroup.getFriendlyURL() +
+						exportLayout.getFriendlyURL(),
+			actualImportedURL);
+	}
+
+	@Test
+	public void testExportDefaultGroupCompanyHostImportPublicPagesVirtualHost()
+		throws Exception {
+
+		Group exportGroup = GroupTestUtil.addGroup();
+
+		Group importGroup = GroupTestUtil.addGroup();
+
+		GroupTestUtil.addLayoutSetVirtualHost(importGroup, false);
+
+		Layout exportLayout = LayoutTestUtil.addLayout(exportGroup);
+
+		String urlToExport =
+			_getCompanyHostPortalURL(exportGroup) +
+				exportLayout.getFriendlyURL();
+
+		String actualImportedURL = _exportAndImportLayoutURL(
+			urlToExport, exportGroup, importGroup, true, false);
+
+		Assert.assertEquals(
+			_getGroupVirtualHostPortalURL(importGroup, false) +
+				exportLayout.getFriendlyURL(),
+			actualImportedURL);
+	}
+
+	@Test
 	public void testExportDefaultGroupPublicPagesVirtualHostImportDefaultGroupNoVirtualHost()
 		throws Exception {
 
@@ -172,6 +221,57 @@ public class LayoutReferencesExportImportContentProcessorTest {
 	}
 
 	@Test
+	public void testExportDefaultGroupPublicPagesVirtualHostImportNoVirtualHost()
+		throws Exception {
+
+		Group exportGroup = GroupTestUtil.addGroup();
+		Group importGroup = GroupTestUtil.addGroup();
+
+		GroupTestUtil.addLayoutSetVirtualHost(exportGroup, false);
+
+		Layout exportLayout = LayoutTestUtil.addLayout(exportGroup);
+
+		String urlToExport =
+			_getGroupVirtualHostPortalURL(exportGroup, false) +
+				exportLayout.getFriendlyURL();
+
+		String actualImportedURL = _exportAndImportLayoutURL(
+			urlToExport, exportGroup, importGroup, true, false);
+
+		Assert.assertEquals(
+			_getCompanyHostPortalURL(importGroup) +
+				PropsValues.LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING +
+					importGroup.getFriendlyURL() +
+						exportLayout.getFriendlyURL(),
+			actualImportedURL);
+	}
+
+	@Test
+	public void testExportDefaultGroupPublicPagesVirtualHostImportPublicPagesVirtualHost()
+		throws Exception {
+
+		Group exportGroup = GroupTestUtil.addGroup();
+		Group importGroup = GroupTestUtil.addGroup();
+
+		GroupTestUtil.addLayoutSetVirtualHost(exportGroup, false);
+		GroupTestUtil.addLayoutSetVirtualHost(importGroup, false);
+
+		Layout exportLayout = LayoutTestUtil.addLayout(exportGroup);
+
+		String urlToExport =
+			_getGroupVirtualHostPortalURL(exportGroup, false) +
+				exportLayout.getFriendlyURL();
+
+		String actualImportedURL = _exportAndImportLayoutURL(
+			urlToExport, exportGroup, importGroup, true, false);
+
+		Assert.assertEquals(
+			_getGroupVirtualHostPortalURL(importGroup, false) +
+				exportLayout.getFriendlyURL(),
+			actualImportedURL);
+	}
+
+	@Test
 	public void testExportDefaultGroupRelativeURLHostImportDefaultGroup()
 		throws Exception {
 
@@ -184,6 +284,46 @@ public class LayoutReferencesExportImportContentProcessorTest {
 
 		String actualImportedURL = _exportAndImportLayoutURL(
 			urlToExport, exportGroup, importGroup, true, true);
+
+		Assert.assertEquals(exportLayout.getFriendlyURL(), actualImportedURL);
+	}
+
+	@Test
+	public void testExportDefaultGroupRelativeURLImportNoVirtualHost()
+		throws Exception {
+
+		Group exportGroup = GroupTestUtil.addGroup();
+		Group importGroup = GroupTestUtil.addGroup();
+
+		Layout exportLayout = LayoutTestUtil.addLayout(exportGroup);
+
+		String urlToExport = exportLayout.getFriendlyURL();
+
+		String actualImportedURL = _exportAndImportLayoutURL(
+			urlToExport, exportGroup, importGroup, true, false);
+
+		Assert.assertEquals(
+			PropsValues.LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING +
+				importGroup.getFriendlyURL() + exportLayout.getFriendlyURL(),
+			actualImportedURL);
+	}
+
+	@Test
+	public void testExportDefaultGroupRelativeURLImportPublicPagesVirtualHost()
+		throws Exception {
+
+		Group exportGroup = GroupTestUtil.addGroup();
+
+		Group importGroup = GroupTestUtil.addGroup();
+
+		GroupTestUtil.addLayoutSetVirtualHost(importGroup, false);
+
+		Layout exportLayout = LayoutTestUtil.addLayout(exportGroup);
+
+		String urlToExport = exportLayout.getFriendlyURL();
+
+		String actualImportedURL = _exportAndImportLayoutURL(
+			urlToExport, exportGroup, importGroup, true, false);
 
 		Assert.assertEquals(exportLayout.getFriendlyURL(), actualImportedURL);
 	}

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/content/processor/test/LayoutReferencesExportImportContentProcessorTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/content/processor/test/LayoutReferencesExportImportContentProcessorTest.java
@@ -1,0 +1,176 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.exportimport.internal.content.processor.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.exportimport.content.processor.ExportImportContentProcessor;
+import com.liferay.exportimport.kernel.lar.PortletDataContext;
+import com.liferay.exportimport.kernel.lar.PortletDataContextFactoryUtil;
+import com.liferay.exportimport.test.util.TestReaderWriter;
+import com.liferay.exportimport.test.util.TestUserIdStrategy;
+import com.liferay.journal.test.util.JournalTestUtil;
+import com.liferay.layout.test.util.LayoutFriendlyURLRandomizerBumper;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.StagedModel;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.Time;
+import com.liferay.portal.kernel.xml.Document;
+import com.liferay.portal.kernel.xml.Element;
+import com.liferay.portal.kernel.xml.SAXReaderUtil;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.registry.Registry;
+import com.liferay.registry.RegistryUtil;
+import com.liferay.registry.ServiceTracker;
+
+import java.util.Date;
+import java.util.HashMap;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Michael Bowerman
+ */
+@RunWith(Arquillian.class)
+public class LayoutReferencesExportImportContentProcessorTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@BeforeClass
+	public static void setUpClass() {
+		Registry registry = RegistryUtil.getRegistry();
+
+		StringBundler sb = new StringBundler(3);
+
+		sb.append("(&(content.processor.type=LayoutReferences)(objectClass=");
+		sb.append(ExportImportContentProcessor.class.getName());
+		sb.append("))");
+
+		_serviceTracker = registry.trackServices(
+			registry.getFilter(sb.toString()));
+
+		_serviceTracker.open();
+	}
+
+	@Before
+	public void setUp() {
+		_layoutReferencesExportImportContentProcessor =
+			_serviceTracker.getService();
+	}
+
+	@Test
+	public void testExternalURLNotModified() throws Exception {
+		Group exportGroup = GroupTestUtil.addGroup();
+		Group importGroup = GroupTestUtil.addGroup();
+
+		String urlToExport = RandomTestUtil.randomString(
+			LayoutFriendlyURLRandomizerBumper.INSTANCE);
+
+		String actualImportedURL = _exportAndImportLayoutURL(
+			urlToExport, exportGroup, importGroup);
+
+		Assert.assertEquals(urlToExport, actualImportedURL);
+	}
+
+	private String _exportAndImportLayoutURL(
+			String url, Group exportGroup, Group importGroup)
+		throws Exception {
+
+		TestReaderWriter testReaderWriter = new TestReaderWriter();
+
+		PortletDataContext exportPortletDataContext =
+			PortletDataContextFactoryUtil.createExportPortletDataContext(
+				exportGroup.getCompanyId(), exportGroup.getGroupId(),
+				new HashMap<>(),
+				new Date(System.currentTimeMillis() - Time.HOUR), new Date(),
+				testReaderWriter);
+
+		Document document = SAXReaderUtil.createDocument();
+
+		Element manifestRootElement = document.addElement("root");
+
+		manifestRootElement.addElement("header");
+
+		testReaderWriter.addEntry("/manifest.xml", document.asXML());
+
+		Element rootElement = SAXReaderUtil.createElement("root");
+
+		exportPortletDataContext.setExportDataRootElement(rootElement);
+
+		Element missingReferencesElement = rootElement.addElement(
+			"missing-references");
+
+		exportPortletDataContext.setMissingReferencesElement(
+			missingReferencesElement);
+
+		StagedModel referrerStagedModel = JournalTestUtil.addArticle(
+			exportGroup.getGroupId(), RandomTestUtil.randomString(),
+			RandomTestUtil.randomString());
+
+		String contentToExport = _CONTENT_PREFIX + url + _CONTENT_POSTFIX;
+
+		String exportedContent =
+			_layoutReferencesExportImportContentProcessor.
+				replaceExportContentReferences(
+					exportPortletDataContext, referrerStagedModel,
+					contentToExport, true, false);
+
+		PortletDataContext importPortletDataContext =
+			PortletDataContextFactoryUtil.createImportPortletDataContext(
+				importGroup.getCompanyId(), importGroup.getGroupId(),
+				new HashMap<>(), new TestUserIdStrategy(), testReaderWriter);
+
+		importPortletDataContext.setImportDataRootElement(rootElement);
+
+		importPortletDataContext.setMissingReferencesElement(
+			missingReferencesElement);
+
+		String importedContent =
+			_layoutReferencesExportImportContentProcessor.
+				replaceImportContentReferences(
+					importPortletDataContext, referrerStagedModel,
+					exportedContent);
+
+		return importedContent.substring(
+			_CONTENT_PREFIX.length(),
+			importedContent.length() - _CONTENT_POSTFIX.length());
+	}
+
+	private static final String _CONTENT_POSTFIX = "\">link</a>";
+
+	private static final String _CONTENT_PREFIX = "<a href=\"";
+
+	private static ServiceTracker
+		<ExportImportContentProcessor<String>,
+		 ExportImportContentProcessor<String>> _serviceTracker;
+
+	private ExportImportContentProcessor<String>
+		_layoutReferencesExportImportContentProcessor;
+
+}

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/content/processor/test/LayoutReferencesExportImportContentProcessorTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/content/processor/test/LayoutReferencesExportImportContentProcessorTest.java
@@ -189,6 +189,74 @@ public class LayoutReferencesExportImportContentProcessorTest {
 	}
 
 	@Test
+	public void testExportPublicPagesVirtualHostImportDefaultGroupNoVirtualHost()
+		throws Exception {
+
+		Group exportGroup = GroupTestUtil.addGroup();
+		Group importGroup = GroupTestUtil.addGroup();
+
+		GroupTestUtil.addLayoutSetVirtualHost(exportGroup, false);
+
+		Layout exportLayout = LayoutTestUtil.addLayout(exportGroup);
+
+		String urlToExport =
+			_getGroupVirtualHostPortalURL(exportGroup, false) +
+				exportLayout.getFriendlyURL();
+
+		String actualImportedURL = _exportAndImportLayoutURL(
+			urlToExport, exportGroup, importGroup, false, true);
+
+		Assert.assertEquals(
+			_getCompanyHostPortalURL(importGroup) +
+				exportLayout.getFriendlyURL(),
+			actualImportedURL);
+	}
+
+	@Test
+	public void testExportPublicPagesVirtualHostImportDefaultGroupPublicPagesVirtualHost()
+		throws Exception {
+
+		Group exportGroup = GroupTestUtil.addGroup();
+		Group importGroup = GroupTestUtil.addGroup();
+
+		GroupTestUtil.addLayoutSetVirtualHost(exportGroup, false);
+		GroupTestUtil.addLayoutSetVirtualHost(importGroup, false);
+
+		Layout exportLayout = LayoutTestUtil.addLayout(exportGroup);
+
+		String urlToExport =
+			_getGroupVirtualHostPortalURL(exportGroup, false) +
+				exportLayout.getFriendlyURL();
+
+		String actualImportedURL = _exportAndImportLayoutURL(
+			urlToExport, exportGroup, importGroup, false, true);
+
+		Assert.assertEquals(
+			_getGroupVirtualHostPortalURL(importGroup, false) +
+				exportLayout.getFriendlyURL(),
+			actualImportedURL);
+	}
+
+	@Test
+	public void testExportRelativeURLImportDefaultGroupNoVirtualHost()
+		throws Exception {
+
+		Group exportGroup = GroupTestUtil.addGroup();
+		Group importGroup = GroupTestUtil.addGroup();
+
+		GroupTestUtil.addLayoutSetVirtualHost(exportGroup, false);
+
+		Layout exportLayout = LayoutTestUtil.addLayout(exportGroup);
+
+		String urlToExport = exportLayout.getFriendlyURL();
+
+		String actualImportedURL = _exportAndImportLayoutURL(
+			urlToExport, exportGroup, importGroup, false, true);
+
+		Assert.assertEquals(exportLayout.getFriendlyURL(), actualImportedURL);
+	}
+
+	@Test
 	public void testExternalURLNotModified() throws Exception {
 		Group exportGroup = GroupTestUtil.addGroup();
 		Group importGroup = GroupTestUtil.addGroup();

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/content/processor/test/LayoutReferencesExportImportContentProcessorTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/content/processor/test/LayoutReferencesExportImportContentProcessorTest.java
@@ -329,6 +329,32 @@ public class LayoutReferencesExportImportContentProcessorTest {
 	}
 
 	@Test
+	public void testExportPrivatePagesVirtualHostURLImportDefaultGroup()
+		throws Exception {
+
+		Group exportGroup = GroupTestUtil.addGroup();
+		Group importGroup = GroupTestUtil.addGroup();
+
+		GroupTestUtil.addLayoutSetVirtualHost(exportGroup, true);
+
+		Layout exportLayout = LayoutTestUtil.addLayout(exportGroup, true);
+
+		String urlToExport =
+			_getGroupVirtualHostPortalURL(exportGroup, true) +
+				exportLayout.getFriendlyURL();
+
+		String actualImportedURL = _exportAndImportLayoutURL(
+			urlToExport, exportGroup, importGroup, false, true);
+
+		Assert.assertEquals(
+			_getCompanyHostPortalURL(importGroup) +
+				PropsValues.LAYOUT_FRIENDLY_URL_PRIVATE_GROUP_SERVLET_MAPPING +
+					importGroup.getFriendlyURL() +
+						exportLayout.getFriendlyURL(),
+			actualImportedURL);
+	}
+
+	@Test
 	public void testExportPublicPagesVirtualHostImportDefaultGroupNoVirtualHost()
 		throws Exception {
 


### PR DESCRIPTION
Hi @dacousalr,

These are the integration tests that Brian Chan requested in https://github.com/brianchandotcom/liferay-portal/pull/105535#issuecomment-898404655.

I created a new test class LayoutReferencesExportImportContentProcessorTest for these test cases. This class is designed in such a way that each test should test a single URL. Each test should set up the export Group and import Group in the way that it wants, then test a single URL being exported and imported, and verify that the resulting URL is as expected.

This differs from the existing DefautlExportImportContentProcessorTest class, which is set up for more "high-level" tests that test an export or import with many URLs, but doesn't really have a good way to examine an individual URL in detail. Thus, I thought it would be worth adding this new test class, especially since the DefaultExportImportContentProcessorTest class is also testing other content processors (such as the DLReferencesExportImportContentProcessor), so adding all these test cases to it would make the class very unwieldy.

Please let me know if you have any questions or disagreements with how I implemented these tests.

https://issues.liferay.com/browse/LPS-136108