### PR TITLE
[TS] LPS-141133 In Web Content, folder and search are not restored when structure filter is removed

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalManagementToolbarDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalManagementToolbarDisplayContext.java
@@ -341,6 +341,8 @@ public class JournalManagementToolbarDisplayContext
 							currentURLObj, liferayPortletResponse)
 					).setNavigation(
 						(String)null
+					).setParameter(
+						"ddmStructureKey", (String)null
 					).buildString());
 
 				labelItem.setCloseable(true);


### PR DESCRIPTION
Hi @dacousalr,

We need to remove 'ddmStructureKey' from the URL when the user removes it from the filter in order to perform the new search.

See [LPS-141133](https://issues.liferay.com/browse/LPS-141133).

Please let me know if you have any questions.