### PR TITLE
[TS] LPS-150132 Staged NavigationMenu in a Public Page doesn't show items for Private Pages

### DIFF
--- a/modules/apps/site-navigation/site-navigation-menu-item-layout/src/main/java/com/liferay/site/navigation/menu/item/layout/internal/type/LayoutSiteNavigationMenuItemType.java
+++ b/modules/apps/site-navigation/site-navigation-menu-item-layout/src/main/java/com/liferay/site/navigation/menu/item/layout/internal/type/LayoutSiteNavigationMenuItemType.java
@@ -25,6 +25,8 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.NoSuchLayoutException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutFriendlyURL;
@@ -98,8 +100,29 @@ public class LayoutSiteNavigationMenuItemType
 
 		Layout layout = _getLayout(portletDataContext, siteNavigationMenuItem);
 
-		if ((layout == null) ||
-			!ArrayUtil.contains(
+		if (layout == null) {
+			return false;
+		}
+
+		boolean privateLayout = layout.isPrivateLayout();
+
+		if (privateLayout != portletDataContext.isPrivateLayout()) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					StringBundler.concat(
+						"SiteNavigationMenuItem ",
+						siteNavigationMenuItem.getSiteNavigationMenuItemId(),
+						" won't be exported because it points to a ",
+						privateLayout ? "private" : "public",
+						" layout. It will be exported when a ",
+						privateLayout ? "private" : "public",
+						" process is performed."));
+			}
+
+			return false;
+		}
+
+		if (!ArrayUtil.contains(
 				portletDataContext.getLayoutIds(), layout.getLayoutId())) {
 
 			return false;
@@ -577,6 +600,9 @@ public class LayoutSiteNavigationMenuItemType
 			GetterUtil.getBoolean(
 				typeSettingsUnicodeProperties.get("setCustomName")));
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		LayoutSiteNavigationMenuItemType.class);
 
 	@Reference
 	private ItemSelector _itemSelector;


### PR DESCRIPTION
Hi @dacousalr,

The result of mixing public and private pages in navigation menus is not consistent when staging is enabled. See  [LPS-150132](https://issues.liferay.com/browse/LPS-150132) for details. 

On the one hand, we have to add an extra condition to [this check](https://github.com/liferay/liferay-portal-ee/blob/7.4.x/modules/apps/site-navigation/site-navigation-menu-item-layout/src/main/java/com/liferay/site/navigation/menu/item/layout/internal/type/LayoutSiteNavigationMenuItemType.java#L102-L103) implemented in [LPS-125086](https://issues.liferay.com/browse/LPS-125086), otherwise the behaviour seems random to the user because a *private* and a *public* page can share the same "layoutId". However, a private page can never be checked in a publication of public pages (and vice versa).

On the other hand, if Page Versioning is enabled, some undesired records are created in the database when performing a publication of public pages and there are navigation menu items for private pages. 
When the execution calls [_getLayout() from LayoutSiteNavigationMenuItemType#exportData()](https://github.com/liferay/liferay-portal-ee/blob/7.4.x/modules/apps/site-navigation/site-navigation-menu-item-layout/src/main/java/com/liferay/site/navigation/menu/item/layout/internal/type/LayoutSiteNavigationMenuItemType.java#L99), you can see how a new row is added to "LayoutBranch" table for the *private* page in the staging site database, but pointing to the *public* "LayoutSetBranch". This is because it tries to get a mater branch [here](https://github.com/liferay/liferay-portal-ee/blob/7.4.x/portal-kernel/src/com/liferay/portal/kernel/model/LayoutStagingHandler.java#L224-L226) that doesn't exist, and it ends up creating a new one. 
Then, the execution of `LayoutStagingHandler#_getLayoutRevision()` continues, and a new *public* "LayoutRevision" for that *private* page [is added too](https://github.com/liferay/liferay-portal-ee/blob/7.4.x/portal-kernel/src/com/liferay/portal/kernel/model/LayoutStagingHandler.java#L234-L244) with INACTIVE status, so `LayoutSiteNavigationMenuItemType#exportData()` always returns *false* [here](https://github.com/liferay/liferay-portal-ee/blob/7.4.13-u16/modules/apps/site-navigation/site-navigation-menu-item-layout/src/main/java/com/liferay/site/navigation/menu/item/layout/internal/type/LayoutSiteNavigationMenuItemType.java#L113 "Follow link").

Please, let me know if you have any questions.

Thanks!
