### PR TITLE
[TECHNICAL SUPPORT] LPS-159309 Widgets will show portlet configuration on content page if they are placed below a drop zone fragment

### DIFF
--- a/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/renderer/FragmentDropZoneRendererImpl.java
+++ b/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/renderer/FragmentDropZoneRendererImpl.java
@@ -20,6 +20,7 @@ import com.liferay.layout.taglib.servlet.taglib.RenderFragmentLayoutTag;
 import com.liferay.petra.io.unsync.UnsyncStringWriter;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.servlet.PipingServletResponse;
+import com.liferay.portal.kernel.util.WebKeys;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -57,6 +58,10 @@ public class FragmentDropZoneRendererImpl implements FragmentDropZoneRenderer {
 		}
 		catch (Exception exception) {
 			throw new FragmentEntryContentException(exception);
+		}
+		finally {
+			httpServletRequest.setAttribute(
+				WebKeys.SHOW_PORTLET_TOPPER, Boolean.TRUE);
 		}
 
 		return unsyncStringWriter.toString();


### PR DESCRIPTION
Hey,

When we start rendering the fragments under the masterLayout with a fragmentLayoutTag, it will set the showPortletTropper attribute to true in the request, and will remove it, once it finished rendering.
The root cause is that the dropZone fragment renders a FragmentLayoutTag as well, that will end up removing the showPortletTopper attribute from the request when finished rendering. When it is set to true, we won't render the portlet configuration, which is the expected behaviour on a content page. However the remaining widgets that we might render under a drop zone on a content page still needs this attribute in the request to not show their configuration.
 My fix restores this attribute once we finished rendering a dropZoneFragment.

Please review my change.

Thanks