### PR TITLE
LPS-178820 Check Site's default language before returning Exception

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -5747,7 +5747,7 @@ public class JournalArticleLocalServiceImpl
 				article.getClassNameId())) {
 
 			urlTitle = urlTitleMap.get(
-				LocaleUtil.toLanguageId(LocaleUtil.getDefault()));
+				LocaleUtil.toLanguageId(LocaleUtil.getSiteDefault()));
 
 			if (Validator.isNull(urlTitle)) {
 				throw new ArticleFriendlyURLException();

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -5746,7 +5746,12 @@ public class JournalArticleLocalServiceImpl
 			(_classNameLocalService.getClassNameId(DDMStructure.class) !=
 				article.getClassNameId())) {
 
-			throw new ArticleFriendlyURLException();
+			urlTitle = urlTitleMap.get(
+				LocaleUtil.toLanguageId(LocaleUtil.getDefault()));
+
+			if (Validator.isNull(urlTitle)) {
+				throw new ArticleFriendlyURLException();
+			}
 		}
 
 		article.setFolderId(folderId);


### PR DESCRIPTION
Hey @dacousalr ,

Could you review this pull request, please?

You can find more details about how to reproduce this issue in [LPS-178820](https://issues.liferay.com/browse/LPS-178820).

Originally I thought about introducing some change in friendly-url-taglib to consider this case, or even adding a new param to that taglib so we can pass a defaulLanguage to it, but after the conversation we both have on Slack with @robertoDiaz I decided to just check on JournalArticle whether there is an URL for Site's default language before returning an exception.

Let me know if you have any question about it.

Thanks.

Regards.